### PR TITLE
feat: add privacy-indicator plugin

### DIFF
--- a/catalog.toml
+++ b/catalog.toml
@@ -57,3 +57,14 @@ icon = "clock"
 description = "A countdown timer desktop widget with start/pause and reset."
 min_noctalia = "5.0.0"
 tags = ["timer", "countdown", "desktop"]
+
+[[plugin]]
+id = "rebiz/privacy-indicator"
+name = "Privacy Indicator"
+version = "1.0.0"
+author = "Rebiz"
+license = "MIT"
+icon = "eye"
+description = "Shows when microphone, camera, or screen sharing is active."
+min_noctalia = "5.0.0"
+tags = ["privacy", "indicator", "microphone", "camera", "screencast"]

--- a/privacy-indicator/plugin.toml
+++ b/privacy-indicator/plugin.toml
@@ -1,0 +1,45 @@
+id = "rebiz/privacy-indicator"
+name = "Privacy Indicator"
+version = "1.0.0"
+min_noctalia = "5.0.0"
+author = "Rebiz"
+license = "MIT"
+tags = ["privacy", "indicator", "microphone", "camera", "screencast"]
+icon = "eye"
+description = "Shows when microphone, camera, or screen sharing is active."
+
+[[setting]]
+key = "hide_inactive"
+type = "bool"
+label = "Hide when inactive"
+description = "Hide the widget from the bar if no microphone, camera, or screen share is active."
+default = false
+
+[[setting]]
+key = "enable_toast"
+type = "bool"
+label = "Enable notifications"
+description = "Show system notifications when microphone, camera, or screen sharing becomes active."
+default = true
+
+[[setting]]
+key = "active_color"
+type = "color"
+label = "Active color"
+description = "Color when active."
+default = "error"
+
+[[setting]]
+key = "inactive_color"
+type = "color"
+label = "Inactive color"
+description = "Color when inactive."
+default = "none"
+
+[[service]]
+id = "privacy_service"
+entry = "privacy_service.luau"
+
+[[widget]]
+id = "indicator"
+entry = "privacy.luau"

--- a/privacy-indicator/privacy.luau
+++ b/privacy-indicator/privacy.luau
@@ -1,0 +1,91 @@
+-- Privacy Indicator — bar widget (thin presentation client).
+--
+-- The detection logic lives in the [[service]] (privacy_service.luau). This
+-- widget only reflects the published "status" state.
+
+local lastStatus = nil
+
+local function buildTooltip(status)
+    if not status then return "Privacy Status" end
+    local parts = {}
+    if status.micActive and #status.micApps > 0 then
+        table.insert(parts, "Mic: " .. table.concat(status.micApps, ", "))
+    end
+    if status.camActive and #status.camApps > 0 then
+        table.insert(parts, "Cam: " .. table.concat(status.camApps, ", "))
+    end
+    if status.scrActive and #status.scrApps > 0 then
+        table.insert(parts, "Screen: " .. table.concat(status.scrApps, ", "))
+    end
+    if #parts == 0 then
+        return "No active capture streams"
+    end
+    return table.concat(parts, "\n")
+end
+
+local function applyStatus(status)
+    lastStatus = status
+    if type(status) ~= "table" then return end
+
+    local hideInactive = noctalia.getConfig("hide_inactive")
+    local activeColor = noctalia.getConfig("active_color") or "error"
+    local inactiveColor = noctalia.getConfig("inactive_color") or "none"
+
+    local activeCount = 0
+    if status.micActive then activeCount += 1 end
+    if status.camActive then activeCount += 1 end
+    if status.scrActive then activeCount += 1 end
+
+    local isAnyActive = activeCount > 0
+
+    if not isAnyActive then
+        barWidget.setGlyph("eye-off")
+        barWidget.setGlyphColor(inactiveColor)
+        barWidget.setColor(inactiveColor)
+        barWidget.setText("")
+        barWidget.setTooltip("No active capture streams")
+        barWidget.setVisible(not hideInactive)
+        return
+    end
+
+    local glyph = "eye"
+    local text = ""
+
+    if activeCount == 1 then
+        if status.micActive then
+            glyph = "microphone"
+            text = "Mic"
+        elseif status.camActive then
+            glyph = "camera"
+            text = "Cam"
+        elseif status.scrActive then
+            glyph = "screen-share"
+            text = "Screen"
+        end
+    else
+        glyph = "eye"
+        text = "Privacy"
+    end
+
+    barWidget.setGlyph(glyph)
+    barWidget.setGlyphColor(activeColor)
+    barWidget.setColor(activeColor)
+    barWidget.setText(text)
+    barWidget.setTooltip(buildTooltip(status))
+    barWidget.setVisible(true)
+end
+
+function onClick()
+    noctalia.runAsync("noctalia msg settings-open")
+end
+
+applyStatus(noctalia.state.get("status") or {
+    micActive = false,
+    micApps = {},
+    camActive = false,
+    camApps = {},
+    scrActive = false,
+    scrApps = {}
+})
+
+noctalia.state.watch("status", applyStatus)

--- a/privacy-indicator/privacy_service.luau
+++ b/privacy-indicator/privacy_service.luau
@@ -1,0 +1,147 @@
+-- Privacy Indicator — headless service.
+-- Ticks every second, queries PipeWire and /sys/class/video4linux for active
+-- microphone, camera, and screen-sharing streams, then publishes to "status".
+
+local pwCmd = [[pw-dump | jq '{
+  nodes: [.[] | select(.type == "PipeWire:Interface:Node") | {id: .id, class: .info.props."media.class", name: .info.props."node.name", app: .info.props."application.name", capture_sink: .info.props."stream.capture.sink", media_name: .info.props."media.name"}],
+  links: [.[] | select(.type == "PipeWire:Interface:Link" and .info.state == "active") | {source: .info."output-node-id", target: .info."input-node-id"}]
+}']]
+
+local camCmd = [[for dev in /sys/class/video4linux/video*; do [ -e "$dev/name" ] && grep -qv 'Metadata' "$dev/name" && dev_name=$(basename "$dev") && find /proc/[0-9]*/fd -lname "/dev/$dev_name" 2>/dev/null; done | cut -d/ -f3 | xargs -r ps -o comm= -p | sort -u | tr '\n' ',' | sed 's/,$//']]
+
+noctalia.setUpdateInterval(1000)
+
+local lastMicActive = false
+local lastCamActive = false
+local lastScrActive = false
+
+local function hasNodeLinks(nodeId, links)
+    for _, link in ipairs(links) do
+        if link.source == nodeId or link.target == nodeId then
+            return true
+        end
+    end
+    return false
+end
+
+function update()
+    local pwDone = false
+    local camDone = false
+    local pwResult = nil
+    local camResult = nil
+
+    local function processResults()
+        if not (pwDone and camDone) then return end
+
+        local status = {
+            micActive = false,
+            micApps = {},
+            camActive = false,
+            camApps = {},
+            scrActive = false,
+            scrApps = {}
+        }
+
+        if pwResult and pwResult.exitCode == 0 then
+            local data = noctalia.json.decode(pwResult.stdout)
+            if data and data.nodes and data.links then
+                local nodes = data.nodes
+                local links = data.links
+
+                local activeNodeIds = {}
+                for _, link in ipairs(links) do
+                    if link.source then activeNodeIds[link.source] = true end
+                    if link.target then activeNodeIds[link.target] = true end
+                end
+
+                for _, node in ipairs(nodes) do
+                    if activeNodeIds[node.id] then
+                        if node.class == "Stream/Input/Audio" and node.capture_sink ~= "true" and node.capture_sink ~= true then
+                            status.micActive = true
+                            local appName = node.app or node.name or "Unknown"
+                            if not table.find(status.micApps, appName) then
+                                table.insert(status.micApps, appName)
+                            end
+                        end
+
+                        local class = node.class or ""
+                        local isVideo = string.find(class, "Video")
+                        local isAudio = string.find(class, "Audio")
+                        if isVideo and not isAudio then
+                            local mediaName = string.lower(node.media_name or "")
+                            if string.match(mediaName, "^xdph%-streaming") or
+                               string.match(mediaName, "^gsr%-default") or
+                               string.match(mediaName, "^game capture") or
+                               string.match(mediaName, "^screen") or
+                               string.match(mediaName, "^desktop") or
+                               string.match(mediaName, "^display") or
+                               string.match(mediaName, "^cast") or
+                               string.match(mediaName, "^webrtc") or
+                               string.match(mediaName, "^v4l2") or
+                               mediaName == "gsr-default_output" or
+                               string.find(mediaName, "screen%-cast") or
+                               string.find(mediaName, "screen%-capture") or
+                               string.find(mediaName, "desktop%-capture") or
+                               string.find(mediaName, "monitor%-capture") or
+                               string.find(mediaName, "window%-capture") or
+                               string.find(mediaName, "game%-capture") then
+
+                                status.scrActive = true
+                                local appName = node.app or node.name or "Unknown"
+                                if not table.find(status.scrApps, appName) then
+                                    table.insert(status.scrApps, appName)
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+        end
+
+        if camResult and camResult.exitCode == 0 then
+            local appsStr = string.gsub(camResult.stdout, "%s+", "")
+            if #appsStr > 0 then
+                for app in string.gmatch(appsStr, "([^,]+)") do
+                    status.camActive = true
+                    if not table.find(status.camApps, app) then
+                        table.insert(status.camApps, app)
+                    end
+                end
+            end
+        end
+
+        local enableToast = noctalia.getConfig("enable_toast")
+        if enableToast ~= false then
+            if status.micActive and not lastMicActive then
+                local appList = #status.micApps > 0 and (" by " .. table.concat(status.micApps, ", ")) or ""
+                noctalia.notify("Microphone Active", "Microphone is being used" .. appList)
+            end
+            if status.camActive and not lastCamActive then
+                local appList = #status.camApps > 0 and (" by " .. table.concat(status.camApps, ", ")) or ""
+                noctalia.notify("Camera Active", "Camera is being used" .. appList)
+            end
+            if status.scrActive and not lastScrActive then
+                local appList = #status.scrApps > 0 and (" by " .. table.concat(status.scrApps, ", ")) or ""
+                noctalia.notify("Screen Sharing Active", "Screen sharing is active" .. appList)
+            end
+        end
+
+        lastMicActive = status.micActive
+        lastCamActive = status.camActive
+        lastScrActive = status.scrActive
+
+        noctalia.state.set("status", status)
+    end
+
+    noctalia.runAsync(pwCmd, function(res)
+        pwResult = res
+        pwDone = true
+        processResults()
+    end)
+
+    noctalia.runAsync(camCmd, function(res)
+        camResult = res
+        camDone = true
+        processResults()
+    end)
+end


### PR DESCRIPTION
Adds a new `privacy-indicator` bar widget plugin that detects active microphone, camera, and screen-sharing streams via PipeWire (`pw-dump`) and `/sys/class/video4linux`, then displays the appropriate icon and app name in the bar.

**Features:**
- Microphone detection via `Stream/Input/Audio` PipeWire nodes
- Camera detection via `/proc` + `/sys/class/video4linux`
- Screen sharing detection via `media.name` matching (xdg-desktop-portal, wlr, obs, etc.)
- Configurable active/inactive colors, hide-when-inactive toggle, and toast notifications
- Left-click opens plugin settings

**Plugin ID:** `rebiz/privacy-indicator`