### PR TITLE
feat(bongocat): add executable_path setting

### DIFF
--- a/bongocat/README.md
+++ b/bongocat/README.md
@@ -38,6 +38,7 @@ Audio reactivity uses Noctalia's PipeWire spectrum callback.
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |
 | `input_devices` | `string_list` | `[]` | Input device paths or globs to read with `evtest`. |
+| `executable_path` | `file` | `evtest` | Path to the input reader executable. |
 | `audio_spectrum` | `bool` | `false` | Enables PipeWire audio spectrum events. |
 | `tappy_mode` | `bool` | `false` | Makes the cat tap its paws to detected beats. |
 | `rave_mode` | `bool` | `false` | Flashes cat colors on detected beats. |

--- a/bongocat/bongocat.luau
+++ b/bongocat/bongocat.luau
@@ -230,16 +230,23 @@ local function startInputReader()
     return
   end
 
-  local executable = barWidget.getConfig("executable_path") or "evtest"
+  local executable = barWidget.getConfig("executable_path")
+
+  if executable == nil or executable == "" then
+    executable = "evtest"
+  end
 
   if not noctalia.commandExists(executable) then
     noctalia.notifyError("Bongo Cat", "the evtest path is invalid (" .. executable .. ") — cannot read input devices")
     return
   end
 
+  -- single-quote for the shell so paths with spaces or metacharacters are safe
+  local quotedExecutable = "'" .. executable:gsub("'", "'\''") .. "'"
+
   local command = "for device in " .. table.concat(patterns, " ")
-      .. '; do [ -e "$device" ] || continue; ' .. executable 
-      .. ' "$device" 2>/dev/null & done; wait'
+    .. '; do [ -e "$device" ] || continue; ' .. quotedExecutable
+    .. ' "$device" 2>/dev/null & done; wait'
 
   if not noctalia.runStream(command, onEvtestLine) then
     noctalia.notifyError("Bongo Cat", "Unable to start input device reader")

--- a/bongocat/bongocat.luau
+++ b/bongocat/bongocat.luau
@@ -229,13 +229,18 @@ local function startInputReader()
   if #patterns == 0 then
     return
   end
-  if not noctalia.commandExists("evtest") then
-    noctalia.notifyError("Bongo Cat", "evtest is not installed — cannot read input devices")
+
+  local executable = barWidget.getConfig("executable_path") or "evtest"
+
+  if not noctalia.commandExists(executable) then
+    noctalia.notifyError("Bongo Cat", "the evtest path is invalid (" .. executable .. ") — cannot read input devices")
     return
   end
 
   local command = "for device in " .. table.concat(patterns, " ")
-      .. '; do [ -e "$device" ] || continue; evtest "$device" 2>/dev/null & done; wait'
+      .. '; do [ -e "$device" ] || continue; ' .. executable 
+      .. ' "$device" 2>/dev/null & done; wait'
+
   if not noctalia.runStream(command, onEvtestLine) then
     noctalia.notifyError("Bongo Cat", "Unable to start input device reader")
   end

--- a/bongocat/plugin.toml
+++ b/bongocat/plugin.toml
@@ -28,6 +28,12 @@ entry = "bongocat.luau"
   default = []
 
   [[widget.setting]]
+  key = "executable_path"
+  type = "file"
+  label_key = "settings.executable_path.label"
+  default = "evtest"
+
+  [[widget.setting]]
   key = "audio_spectrum"
   type = "bool"
   label_key = "settings.audio_spectrum.label"

--- a/bongocat/translations/en.json
+++ b/bongocat/translations/en.json
@@ -4,6 +4,9 @@
       "label": "Input devices",
       "description": "Prefer /dev/input/by-id/*-event-* or /dev/input/by-path/*-event-*; /dev/input/eventN can change after kernel or device updates"
     },
+    "executable_path": {
+      "label": "Alternative evtest binary"
+    },
     "audio_spectrum": {
       "label": "React to audio"
     },


### PR DESCRIPTION

## Summary

<!-- What changed and why? -->

Added `executable_path` setting, replacing the previous hardcoded executable path.

## Motivation

<!-- What problem does this solve? -->
See #4.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #4.

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

Tested the `executable_path` setting with:
- **Valid paths:** `evtest`, `/usr/bin/evtest`, `/run/current-system/sw/bin/evtest`
- **Invalid paths:** `/path`, `/path/`, `/usr/`, `/` 

*(Note: Directory paths like `/` and `/usr/` should give an error but don't do so, see [noctalia#3167](https://github.com/noctalia-dev/noctalia/issues/3167))*

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [x] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
