### PR TITLE
feat(translator): allow configuring target language through settings

### DIFF
--- a/translator/README.md
+++ b/translator/README.md
@@ -8,7 +8,7 @@ Translate and copies the selected result to the clipboard.
 | Field | Value |
 | --- | --- |
 | ID | `noctalia/translator` |
-| Version | `1.0.4` |
+| Version | `1.0.5` |
 | Minimum Noctalia | `5.0.0` |
 | Entry | Launcher provider: `translate` |
 | Prefix | `/tr` |

--- a/translator/plugin.toml
+++ b/translator/plugin.toml
@@ -1,6 +1,6 @@
 id = "noctalia/translator"
 name = "Translator"
-version = "1.0.4"
+version = "1.0.5"
 min_noctalia = "5.0.0"
 author = "noctalia"
 license = "MIT"
@@ -18,9 +18,10 @@ glyph = "language"
 include_in_global_search = false
 debounce_ms = 300  # wait for typing to settle before calling Google
 
-  [[launcher_provider.setting]]
-  key = "target_lang"
-  type = "string"
-  label_key = "settings.target_lang.label"
-  description_key = "settings.target_lang.description"
-  default = "en"
+
+[[setting]]
+key = "target_lang"
+type = "string"
+label_key = "settings.target_lang.label"
+description_key = "settings.target_lang.description"
+default = "en"


### PR DESCRIPTION
## Summary

Change the `launcher_provider.setting` to regular `setting` in translator plugin.
This allows for modifying default target language through the settings GUI, without modifying source files directly.

I'm not sure exactly if this is the best approach, but currently I don't see a way of modifying `launcher_provider.setting` through the settings GUI.

## Motivation

In translator plugin - allow changing default target language through the settings GUI.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing

I modified the downloaded plugin source code with this change and checked if the language cna be changed.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [x] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
