### PR TITLE
feat(screen_recorder): added a replay filename pattern setting

### DIFF
--- a/screen_recorder/plugin.toml
+++ b/screen_recorder/plugin.toml
@@ -154,6 +154,14 @@ max = 3600
 visible_when = { key = "replay_enabled", values = ["true"] }
 
 [[setting]]
+key = "replay_filename_pattern"
+type = "string"
+label_key = "settings.replay_filename_pattern.label"
+default = "replay_%Y%m%d_%H%M%S"
+description_key = "settings.replay_filename_pattern.description"
+visible_when = { key = "replay_enabled", values = ["true"] }
+
+[[setting]]
 key = "replay_storage"
 type = "select"
 label_key = "settings.replay_storage.label"

--- a/screen_recorder/recorder_service.luau
+++ b/screen_recorder/recorder_service.luau
@@ -363,14 +363,20 @@ local function saveReplay()
     local pattern = cfg("replay_filename_pattern")
     if pattern ~= nil and pattern ~= "" then
         local dir = outputDirectory()
-        local gsrFile = `{dir}Replay_{noctalia.formatTime("%Y-%m-%d_%H-%M-%S")}.mp4`
         local targetFile = `{dir}{noctalia.formatTime(pattern)}.mp4`
-        local attempts = 25
+        -- Replay mode only accepts an output directory (-o "{dir}"), so gpu-screen-recorder
+        -- names the file itself as Replay_<timestamp>.mp4 using its own clock when it
+        -- finalizes. Rather than predict that name, poll for the newest Replay_*.mp4 the
+        -- save produced and rename it. `ref` (one second before the SIGUSR1) bounds the
+        -- search so an earlier replay sitting in the directory is never picked up.
+        local ref = (tonumber(noctalia.formatTime("%s")) or 0) - 1
+        local claim = `f=$(find {shellQuote(dir)} -maxdepth 1 -name 'Replay_*.mp4' -newermt "@{ref}" -printf '%T@ %p\\n' 2>/dev/null | sort -n | tail -1 | cut -d' ' -f2-); `
+            .. `if [ -n "$f" ]; then mv -n -- "$f" {shellQuote(targetFile)}; else exit 1; fi`
+        local attempts = 50
         local function poll()
-            noctalia.runAsync("sleep 0.2", function()
-                if noctalia.fileExists(gsrFile) then
-                    noctalia.runAsync(`mv -- {shellQuote(gsrFile)} {shellQuote(targetFile)} 2>/dev/null || true`)
-                elseif attempts > 0 then
+            noctalia.runAsync(`sleep 0.2; {claim}`, function(result)
+                if result.exitCode == 0 then return end
+                if attempts > 0 then
                     attempts -= 1
                     poll()
                 end

--- a/screen_recorder/recorder_service.luau
+++ b/screen_recorder/recorder_service.luau
@@ -359,6 +359,26 @@ end
 local function saveReplay()
     if state ~= "replaying" then return end
     noctalia.runAsync("pkill -SIGUSR1 -f 'gpu-screen-recorder.*-r ' 2>/dev/null || true")
+
+    local pattern = cfg("replay_filename_pattern")
+    if pattern ~= nil and pattern ~= "" then
+        local dir = outputDirectory()
+        local gsrFile = `{dir}Replay_{noctalia.formatTime("%Y-%m-%d_%H-%M-%S")}.mp4`
+        local targetFile = `{dir}{noctalia.formatTime(pattern)}.mp4`
+        local attempts = 25
+        local function poll()
+            noctalia.runAsync("sleep 0.2", function()
+                if noctalia.fileExists(gsrFile) then
+                    noctalia.runAsync(`mv -- {shellQuote(gsrFile)} {shellQuote(targetFile)} 2>/dev/null || true`)
+                elseif attempts > 0 then
+                    attempts -= 1
+                    poll()
+                end
+            end)
+        end
+        poll()
+    end
+
     noctalia.notify(noctalia.tr("notify.replay-saved"))
 end
 

--- a/screen_recorder/translations/en.json
+++ b/screen_recorder/translations/en.json
@@ -98,6 +98,10 @@
     "replay_duration": {
       "label": "Replay seconds"
     },
+    "replay_filename_pattern": {
+      "label": "Replay filename pattern",
+      "description": "Date-format pattern for saved replays without extension; use %s for Unix timestamp"
+    },
     "replay_storage": {
       "label": "Replay storage",
       "options": {

--- a/screen_recorder/translations/fr.json
+++ b/screen_recorder/translations/fr.json
@@ -98,6 +98,10 @@
     "replay_duration": {
       "label": "Secondes de relecture"
     },
+    "replay_filename_pattern": {
+      "label": "Modèle de nom de fichier de relecture",
+      "description": "Modèle de date pour les relectures sauvegardées sans extension; utilisez %s pour l'horodatage Unix"
+    },
     "replay_storage": {
       "label": "Stockage de relecture",
       "options": {


### PR DESCRIPTION
## Summary
Added a replay_filename_pattern setting that lets you customize the filename format of saved replays just like for the recordings. 

## Motivation
Wanted to change the filename pattern for replays just like I had done with recordings.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing
- Tested with different patterns like %y-%m-%d-%H-%M-%S and %s
- Made sure it falls back to the default when nothing is set

## Manual Coverage
- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos
https://github.com/user-attachments/assets/cb5d7337-20d4-4908-919c-a0af2059836e

## Checklist
- [x] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [x] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.

## Additional Notes
I speak french so I went ahead and edited the fr.json translations too