### PR TITLE
Spotify-Lyrics_widget

### DIFF
--- a/spotify-lyrics/README.md
+++ b/spotify-lyrics/README.md
@@ -1,0 +1,57 @@
+# Noctalia Synced Lyrics Plugin
+
+A seamless, time-synced scrolling lyrics panel for the Noctalia desktop shell. It integrates directly into your Noctalia bar and displays a beautifully formatted, auto-scrolling lyrics card when you click the `♫` icon.
+
+## Why it's great
+* **Zero Configuration:** No Spotify `sp_dc` cookies, API keys, or web scraping required! It pulls lyrics from public databases like LRCLIB and NetEase automatically.
+* **Blazing Fast:** Uses a lightweight Python background daemon that caches lyrics to your disk so subsequent plays load in 0ms.
+* **Native Shell Integration:** Doesn't feel like a clunky third-party app. It uses Noctalia's native declarative UI framework for buttery smooth, theme-aware rendering.
+
+## Installation
+
+### 1. Install Dependencies
+You need `playerctl` and the `syncedlyrics` python package.
+```bash
+# Arch Linux
+sudo pacman -S playerctl
+pip install syncedlyrics
+```
+
+### 2. Set up the Background Daemon
+The daemon listens to your media player (Spotify, MPD, etc.) and fetches the lyrics.
+
+1. Copy the `spotify_lyrics_daemon.py` file to your preferred location (e.g., `~/.local/bin/`).
+2. Set it up to run in the background. The recommended way is using a systemd user service:
+
+```ini
+# ~/.config/systemd/user/noctalia-lyrics.service
+[Unit]
+Description=Noctalia Lyrics Daemon
+After=graphical-session.target
+
+[Service]
+ExecStart=/usr/bin/python3 /path/to/spotify_lyrics_daemon.py
+Restart=always
+
+[Install]
+WantedBy=default.target
+```
+Start and enable the daemon:
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now noctalia-lyrics.service
+```
+
+### 3. Enable the Noctalia Plugin
+1. Copy the plugin folder to your Noctalia plugins directory: `~/.local/share/noctalia/plugins/spotify-lyrics/`
+2. Enable the plugin:
+```bash
+noctalia msg plugins enable noctalia/spotify-lyrics
+```
+3. Add the `lyrics` widget to your bar's layout in your `~/.local/state/noctalia/settings.toml` file (next to the `media` widget).
+
+```toml
+start = [ "launcher", "workspaces", "media", "lyrics" ]
+```
+
+That's it! Play a song on Spotify and a `♫` icon will appear in your bar. Click it to view the synced lyrics.

--- a/spotify-lyrics/bar.luau
+++ b/spotify-lyrics/bar.luau
@@ -1,0 +1,36 @@
+--!nonstrict
+-- Minimal bar trigger: shows a small lyrics glyph next to the media widget.
+-- Auto-hides when no music is playing. Click to toggle the lyrics panel.
+
+local function readState()
+  local content = noctalia.readFile("~/.cache/noctalia/lyrics/current.json")
+  if not content then return nil end
+  local state, _ = noctalia.json.decode(content)
+  return state
+end
+
+local tickCount = 0
+
+function update()
+  noctalia.setUpdateInterval(100)
+  tickCount = tickCount + 1
+  noctalia.state.set("lyricsTick", tickCount)
+
+  local state = readState()
+
+  if not state or state.status == "Stopped" or state.status == "" then
+    barWidget.setVisible(false)
+    return
+  end
+
+  barWidget.setVisible(true)
+  barWidget.setGlyph("music")
+  barWidget.setText("")
+  barWidget.setGlyphColor("primary")
+
+  barWidget.setTooltip(state.current or "...")
+end
+
+function onClick()
+  noctalia.togglePanel("noctalia/spotify-lyrics:lyrics-panel")
+end

--- a/spotify-lyrics/panel.luau
+++ b/spotify-lyrics/panel.luau
@@ -1,0 +1,119 @@
+--!nonstrict
+-- Lyrics panel: 3-line synced view (prev / current / next).
+-- Anchored to the bar widget so it feels like part of the media controls.
+
+local function readState()
+  local content = noctalia.readFile("~/.cache/noctalia/lyrics/current.json")
+  if not content then return nil end
+  local state, _ = noctalia.json.decode(content)
+  return state
+end
+
+local function render()
+  local state = readState()
+
+  -- No music
+  if not state or state.status == "Stopped" or state.status == "" then
+    panel.render(ui.column({ flexGrow = 1, gap = 8, align = "stretch", justify = "center", padding = 16 }, {
+      ui.row({ justify = "center" }, { ui.glyph({ name = "music", size = 28, color = "on_surface/0.2" }) }),
+      ui.label({ text = "No music playing", fontSize = 14, fontWeight = "medium", color = "on_surface/0.25", textAlign = "center" }),
+    }))
+    return
+  end
+
+  -- Paused
+  if state.status == "Paused" then
+    panel.render(ui.column({ flexGrow = 1, gap = 6, align = "stretch", justify = "center", padding = 16 }, {
+      ui.row({ gap = 6, justify = "center", align = "center" }, {
+        ui.glyph({ name = "player-pause", size = 16, color = "on_surface/0.3" }),
+        ui.label({
+          text = `{state.title or "Paused"} — {state.artist or ""}`,
+          fontSize = 12,
+          fontWeight = "medium",
+          color = "on_surface/0.4",
+          textAlign = "center",
+          wrap = true,
+        }),
+      }),
+      ui.label({
+        text = state.current or "Paused",
+        fontSize = 18,
+        fontWeight = "bold",
+        color = "on_surface/0.6",
+        textAlign = "center",
+        wrap = true,
+      }),
+    }))
+    return
+  end
+
+  -- ── Playing ──
+
+  local rows = {}
+
+  -- Track header
+  if state.title and state.artist then
+    table.insert(rows, ui.column({ gap = 4, align = "stretch" }, {
+      ui.row({ justify = "center" }, { ui.glyph({ name = "music", size = 14, color = "primary/0.7" }) }),
+      ui.label({
+        text = `{state.title} • {state.artist}`,
+        fontSize = 12,
+        fontWeight = "medium",
+        color = "primary/0.7",
+        textAlign = "center",
+        wrap = true,
+      }),
+    }))
+    table.insert(rows, ui.box({ height = 1, fill = "on_surface/0.06" }))
+  end
+
+  -- Previous line (faded)
+  local prevText = state.prev or ""
+  if prevText ~= "" then
+    table.insert(rows, ui.label({
+      text = prevText,
+      fontSize = 14,
+      fontWeight = "medium",
+      color = "on_surface/0.4",
+      wrap = true,
+      textAlign = "center",
+    }))
+  else
+    table.insert(rows, ui.box({ height = 16 }))
+  end
+
+  -- Current line (bold, prominent)
+  table.insert(rows, ui.label({
+    text = state.current or "...",
+    fontSize = 18,
+    fontWeight = "bold",
+    color = "on_surface/0.95",
+    wrap = true,
+    textAlign = "center",
+  }))
+
+  -- Next line (faded)
+  local nextText = state.next or ""
+  if nextText ~= "" then
+    table.insert(rows, ui.label({
+      text = nextText,
+      fontSize = 14,
+      fontWeight = "medium",
+      color = "on_surface/0.4",
+      wrap = true,
+      textAlign = "center",
+    }))
+  else
+    table.insert(rows, ui.box({ height = 16 }))
+  end
+
+  panel.render(ui.column({ flexGrow = 1, gap = 8, align = "stretch", justify = "center", padding = 16 }, rows))
+end
+
+noctalia.state.watch("lyricsTick", function(_value)
+  render()
+end)
+
+function onOpen(_context)
+  render()
+end

--- a/spotify-lyrics/plugin.toml
+++ b/spotify-lyrics/plugin.toml
@@ -1,0 +1,23 @@
+id = "noctalia/spotify-lyrics"
+name = "Spotify Lyrics"
+version = "1.2.0"
+min_noctalia = "5.0.0"
+author = "goatnath"
+license = "MIT"
+dependencies = []
+tags = ["music", "lyrics"]
+icon = "music"
+description = "Time-synced lyrics panel linked to the media widget."
+
+# Minimal bar trigger: tiny glyph icon next to the media widget.
+# Auto-hides when nothing is playing. Click to open the lyrics panel.
+[[widget]]
+id = "lyrics"
+entry = "bar.luau"
+
+# Lyrics panel: 3-line synced view anchored near the media area.
+[[panel]]
+id = "lyrics-panel"
+entry = "panel.luau"
+width = 460
+height = 200

--- a/spotify-lyrics/spotify_lyrics_daemon.py
+++ b/spotify-lyrics/spotify_lyrics_daemon.py
@@ -1,0 +1,190 @@
+import os
+import time
+import json
+import subprocess
+import threading
+import syncedlyrics
+from pathlib import Path
+
+# Config
+CACHE_DIR = Path.home() / ".cache" / "noctalia" / "lyrics"
+CACHE_DIR.mkdir(parents=True, exist_ok=True)
+CURRENT_STATE_FILE = CACHE_DIR / "current.json"
+
+class SpotifyLyricsDaemon:
+    def __init__(self):
+        self.lyrics_cache = {}  # song_key -> list of lines
+        self.fetching_keys = set()  # Tracks keys currently fetching in the background
+
+    def clean_filename(self, name):
+        return "".join(c for c in name if c.isalnum() or c in (" ", "_", "-")).strip()
+
+    def get_parsed_lyrics(self, title, artist):
+        song_key = f"{artist} - {title}"
+        if song_key in self.lyrics_cache:
+            return self.lyrics_cache[song_key]
+        
+        # Check local disk cache first
+        safe_name = self.clean_filename(song_key)
+        lrc_file = CACHE_DIR / f"{safe_name}.lrc"
+        
+        if lrc_file.exists():
+            parsed = self.load_lrc_file(lrc_file)
+            self.lyrics_cache[song_key] = parsed
+            return parsed
+        
+        # Fetch from syncedlyrics asynchronously to prevent daemon thread lag
+        if song_key not in self.fetching_keys:
+            self.fetching_keys.add(song_key)
+            threading.Thread(
+                target=self._async_fetch_lyrics, 
+                args=(song_key, lrc_file), 
+                daemon=True
+            ).start()
+        
+        return []
+
+    def _async_fetch_lyrics(self, song_key, lrc_file):
+        try:
+            print(f"[Daemon] Fetching lyrics in background for: {song_key}...")
+            lrc_text = syncedlyrics.search(song_key, providers=["NetEase", "Lrclib"])
+            if lrc_text:
+                with open(lrc_file, "w", encoding="utf-8") as f:
+                    f.write(lrc_text)
+                
+                parsed = self.parse_lrc_text(lrc_text)
+                self.lyrics_cache[song_key] = parsed
+                print(f"[Daemon] Fetch completed for: {song_key}")
+            else:
+                print(f"[Daemon] No lyrics found online for: {song_key}")
+        except Exception as e:
+            print(f"[Daemon] Error fetching lyrics for {song_key}: {e}")
+        finally:
+            self.fetching_keys.discard(song_key)
+
+    def parse_lrc_text(self, lrc_text):
+        parsed = []
+        for line in lrc_text.splitlines():
+            # Format: [mm:ss.xx] Text
+            if line.startswith("[") and "]" in line:
+                parts = line.split("]", 1)
+                time_part = parts[0].replace("[", "").strip()
+                text = parts[1].strip()
+                
+                try:
+                    # mm:ss.xx or mm:ss
+                    if "." in time_part:
+                        min_sec, hund = time_part.split(".")
+                        hund_val = int(hund) * 10 if len(hund) == 2 else int(hund)
+                    else:
+                        min_sec = time_part
+                        hund_val = 0
+                    
+                    minutes, seconds = min_sec.split(":")
+                    time_ms = ((int(minutes) * 60) + int(seconds)) * 1000 + hund_val
+                    parsed.append({"time_ms": time_ms, "text": text})
+                except Exception:
+                    pass
+        return parsed
+
+    def load_lrc_file(self, lrc_file):
+        try:
+            with open(lrc_file, "r", encoding="utf-8") as f:
+                return self.parse_lrc_text(f.read())
+        except Exception as e:
+            print(f"[Daemon] Error reading LRC file: {e}")
+        return []
+
+    def get_player_status(self):
+        try:
+            # Query active players
+            players = subprocess.check_output(["playerctl", "-l"], stderr=subprocess.DEVNULL).decode("utf-8").strip().splitlines()
+            if not players:
+                return None
+            
+            # Prioritize Spotify
+            player_name = "spotify" if "spotify" in players else players[0]
+            
+            # Query all metadata in ONE execution using custom delimiters to eliminate subprocess latency
+            output = subprocess.check_output([
+                "playerctl", "-p", player_name, "metadata", 
+                "--format", "{{status}}|||{{position}}|||{{title}}|||{{artist}}"
+            ], stderr=subprocess.DEVNULL).decode("utf-8").strip()
+            
+            parts = output.split("|||")
+            if len(parts) >= 4:
+                status, pos_us, title, artist = parts[0], parts[1], parts[2], parts[3]
+                
+                # Position is in microseconds (us), convert to milliseconds (ms)
+                position_ms = int(int(pos_us) / 1000)
+                
+                return {
+                    "status": status,
+                    "position_ms": position_ms,
+                    "title": title,
+                    "artist": artist
+                }
+        except Exception:
+            pass
+        return None
+
+    def run(self):
+        print("[Daemon] Starting Universal lyrics cache daemon...")
+        
+        while True:
+            player = self.get_player_status()
+            
+            if not player or not player["title"]:
+                # Write empty/inactive state
+                empty_state = {"status": "Stopped"}
+                with open(CURRENT_STATE_FILE, "w", encoding="utf-8") as f:
+                    json.dump(empty_state, f)
+                time.sleep(1.0)
+                continue
+            
+            title = player["title"]
+            artist = player["artist"]
+            
+            lyrics_lines = self.get_parsed_lyrics(title, artist)
+            
+            # Find active line
+            active_idx = -1
+            pos_ms = player["position_ms"]
+            
+            for i, line in enumerate(lyrics_lines):
+                if pos_ms >= line["time_ms"]:
+                    active_idx = i
+                else:
+                    break
+            
+            # Get surrounding lines
+            prev_prev = lyrics_lines[active_idx - 2]["text"] if active_idx >= 2 else ""
+            prev = lyrics_lines[active_idx - 1]["text"] if active_idx >= 1 else ""
+            current = lyrics_lines[active_idx]["text"] if active_idx >= 0 else "..."
+            next_line = lyrics_lines[active_idx + 1]["text"] if active_idx >= 0 and active_idx + 1 < len(lyrics_lines) else ""
+            next_next = lyrics_lines[active_idx + 2]["text"] if active_idx >= 0 and active_idx + 2 < len(lyrics_lines) else ""
+            
+            state = {
+                "status": player["status"],
+                "title": title,
+                "artist": artist,
+                "prev_prev": prev_prev,
+                "prev": prev,
+                "current": current,
+                "next": next_line,
+                "next_next": next_next
+            }
+            
+            # Save state
+            with open(CURRENT_STATE_FILE, "w", encoding="utf-8") as f:
+                json.dump(state, f)
+            
+            # Update more frequently if playing to maintain tight sync
+            if player["status"] == "Playing":
+                time.sleep(0.1)  # Faster updates (100ms) for ultra-tight sync
+            else:
+                time.sleep(1.0)
+
+if __name__ == "__main__":
+    daemon = SpotifyLyricsDaemon()
+    daemon.run()

--- a/spotify-lyrics/widget.luau
+++ b/spotify-lyrics/widget.luau
@@ -1,0 +1,107 @@
+--!nonstrict
+-- Spotify Lyrics desktop widget.
+-- Reads current lyrics state written by the Python daemon.
+-- Displays 3 lines: previous → current (highlighted) → next.
+
+local function render(lyricsState)
+  -- When idle or paused, show a minimal status indicator
+  if not lyricsState or lyricsState.status == "Stopped" or lyricsState.status == "" then
+    desktopWidget.render(ui.column({ gap = 8, align = "center" }, {
+      ui.glyph({ name = "music", size = 28, color = "on_surface/0.3" }),
+      ui.label({
+        text = "No music playing",
+        fontSize = 16,
+        fontWeight = "medium",
+        color = "on_surface/0.3",
+      }),
+    }))
+    return
+  end
+
+  if lyricsState.status == "Paused" then
+    desktopWidget.render(ui.column({ gap = 8, align = "center" }, {
+      ui.glyph({ name = "player-pause", size = 22, color = "on_surface/0.4" }),
+      ui.label({
+        text = lyricsState.current or "Paused",
+        fontSize = 22,
+        fontWeight = "bold",
+        color = "on_surface/0.5",
+      }),
+    }))
+    return
+  end
+
+  -- ── Playing: render 3-line synced lyrics ──
+
+  local rows = {}
+
+  -- Track info: small, subtle line at the top
+  if lyricsState.title and lyricsState.artist then
+    table.insert(rows, ui.row({ gap = 6, align = "center" }, {
+      ui.glyph({ name = "music", size = 12, color = "primary/0.7" }),
+      ui.label({
+        text = `{lyricsState.title} — {lyricsState.artist}`,
+        fontSize = 11,
+        fontWeight = "medium",
+        color = "primary/0.6",
+      }),
+    }))
+  end
+
+  -- Thin separator
+  table.insert(rows, ui.box({ height = 1, fill = "on_surface/0.08" }))
+
+  -- Previous line (dimmed)
+  local prevText = lyricsState.prev or ""
+  if prevText ~= "" then
+    table.insert(rows, ui.label({
+      text = prevText,
+      fontSize = 18,
+      fontWeight = "normal",
+      color = "on_surface/0.3",
+    }))
+  else
+    table.insert(rows, ui.box({ height = 18 })) -- spacer to keep layout stable
+  end
+
+  -- Current line (bold, large, highlighted)
+  local currentText = lyricsState.current or "..."
+  table.insert(rows, ui.label({
+    text = currentText,
+    fontSize = 26,
+    fontWeight = "bold",
+    color = "on_surface",
+  }))
+
+  -- Next line (dimmed)
+  local nextText = lyricsState.next or ""
+  if nextText ~= "" then
+    table.insert(rows, ui.label({
+      text = nextText,
+      fontSize = 18,
+      fontWeight = "normal",
+      color = "on_surface/0.3",
+    }))
+  else
+    table.insert(rows, ui.box({ height = 18 })) -- spacer
+  end
+
+  desktopWidget.render(ui.column({ gap = 10, align = "center" }, rows))
+end
+
+function update()
+  -- 100ms refresh for tight sync
+  noctalia.setUpdateInterval(100)
+
+  local path = "~/.cache/noctalia/lyrics/current.json"
+  local content = noctalia.readFile(path)
+  if content then
+    local state, err = noctalia.json.decode(content)
+    if state then
+      render(state)
+      return
+    end
+  end
+
+  render(nil)
+end


### PR DESCRIPTION

## Summary

Added a new `spotify-lyrics` plugin for the Noctalia desktop shell. This plugin integrates directly into the Noctalia bar and displays a beautifully formatted, time-synced auto-scrolling lyrics card when you click the `♫` icon.

It utilizes a lightweight Python background daemon (using the `syncedlyrics` package) that fetches from public databases without requiring any configuration like `sp_dc` cookies or API keys, and caches them locally for zero-latency loading on subsequent plays.

## Motivation

There was no native, zero-configuration way to view synced lyrics seamlessly inside the Noctalia shell. This plugin solves this by adding an elegant lyrics panel that feels completely native, matches the system themes, and works out-of-the-box without painful API setups. 

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->
N/A

## Testing

Manually tested the Python daemon for lyrics fetching and caching. Tested the UI widget to ensure it renders correctly, handles the sync timing smoothly, and cleanly toggles the lyrics panel upon clicking the bar icon.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor: 
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

*(Note: Please update the checkboxes above if you tested on different compositors/setups!)*

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
*(Note: Be sure to drag and drop a screenshot or screen recording of the lyrics widget in action here before submitting!)*

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [x] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.

## Additional Notes

The Python daemon `spotify_lyrics_daemon.py` is included directly in the plugin directory so users can easily copy it to their system and set it up as a systemd service.
