### PR TITLE
fix(wallhaven): use specific ratios for all-wide and all-portrait

### DIFF
--- a/wallhaven/panel.luau
+++ b/wallhaven/panel.luau
@@ -153,8 +153,8 @@ end
 local function aspectRatioOptions()
   return {
     "",
-    "wide",
-    "portrait",
+    "16x9,16x10,21x9,32x9,48x9",
+    "9x16,10x16,9x18",
     "16x9",
     "16x10",
     "21x9",


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

The all wide and portrait aspect ratios were supposed to have specific values instead of wide or portrait as values

## Motivation

More accurate wallpapers if All Wide or All Portrait option is selected

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [ ] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [ ] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
