### PR TITLE
fix(wallhaven): fix aspect ratio queries and client-side filtering

### DIFF
--- a/wallhaven/panel.luau
+++ b/wallhaven/panel.luau
@@ -702,6 +702,7 @@ render = function()
       ui.input({
         key = "search",
         placeholder = tr("search_placeholder"),
+        value = query,
         flexGrow = 1,
         onChange = "onSearchChange",
         onSubmit = "onSearchSubmit",

--- a/wallhaven/panel.luau
+++ b/wallhaven/panel.luau
@@ -52,7 +52,7 @@ local fetchWallpapers
 local applyWallpaper
 
 local sortOptions = { "relevance", "random", "date_added", "views", "favorites", "toplist", "hot" }
-local sortIndex = 0
+local sortIndex = 2
 local sortOrder = "desc"
 
 local function tr(key)
@@ -227,7 +227,7 @@ local function buildAspectRatioParam()
   local ratios = aspectRatioOptions()
   local ratio = ratios[aspectRatioIndex + 1] or ""
   if ratio ~= "" then
-    return ratio
+    return noctalia.string.urlEncode(ratio)
   end
   return nil
 end

--- a/wallhaven/panel.luau
+++ b/wallhaven/panel.luau
@@ -153,8 +153,8 @@ end
 local function aspectRatioOptions()
   return {
     "",
-    "16x9,16x10,21x9,32x9,48x9",
-    "9x16,10x16,9x18",
+    "wide",
+    "portrait",
     "16x9",
     "16x10",
     "21x9",
@@ -175,19 +175,28 @@ local function aspectRatioLabelList()
     tr("ratio_any"),
     tr("ratio_wide"),
     tr("ratio_portrait"),
-    "16x9",
-    "16x10",
-    "21x9",
-    "32x9",
-    "48x9",
-    "9x16",
-    "10x16",
-    "9x18",
-    "1x1",
-    "3x2",
-    "4x3",
-    "5x4",
+    "16:9",
+    "16:10",
+    "21:9",
+    "32:9",
+    "48:9",
+    "9:16",
+    "10:16",
+    "9:18",
+    "1:1",
+    "3:2",
+    "4:3",
+    "5:4",
   }
+end
+
+local function aspectRatioParamValue()
+  local ratios = aspectRatioOptions()
+  local ratio = ratios[aspectRatioIndex + 1] or ""
+  if ratio == "" then return nil end
+  if ratio == "wide" then return "landscape" end
+  if ratio == "portrait" then return "portrait" end
+  return ratio
 end
 
 local function resolutionModeOptions()
@@ -221,15 +230,6 @@ local function buildResolutionParam()
     end
   end
   return nil, nil
-end
-
-local function buildAspectRatioParam()
-  local ratios = aspectRatioOptions()
-  local ratio = ratios[aspectRatioIndex + 1] or ""
-  if ratio ~= "" then
-    return noctalia.string.urlEncode(ratio)
-  end
-  return nil
 end
 
 local function filterChip(label, active, onClick, key, enabled)
@@ -514,7 +514,7 @@ fetchWallpapers = function()
     table.insert(params, `{resolutionParamName}={resolutionValue}`)
   end
   
-  local aspectRatio = buildAspectRatioParam()
+  local aspectRatio = aspectRatioParamValue()
   if aspectRatio ~= nil then
     table.insert(params, `ratios={aspectRatio}`)
   end
@@ -538,7 +538,47 @@ fetchWallpapers = function()
       return
     end
 
-    wallpapers = data
+    local filteredWallpapers = {}
+    local options = aspectRatioOptions()
+    local selectedRatio = options[aspectRatioIndex + 1] or ""
+    
+    for _, wallpaper in ipairs(data) do
+      local include = true
+      
+      -- Client-side aspect ratio check since API's ratio filter is often inaccurate
+      if selectedRatio ~= "" then
+        local res = wallpaper.resolution
+        if type(res) == "string" then
+          local w, h = res:match("(%d+)x(%d+)")
+          if w and h then
+            w, h = tonumber(w), tonumber(h)
+            local ratio = w / h
+            local isWide = ratio > 1
+            local isPortrait = ratio < 1
+            
+            if selectedRatio == "wide" and not isWide then
+              include = false
+            elseif selectedRatio == "portrait" and not isPortrait then
+              include = false
+            elseif selectedRatio:find("x") then
+              local rw, rh = selectedRatio:match("(%d+)x(%d+)")
+              if rw and rh then
+                local targetRatio = tonumber(rw) / tonumber(rh)
+                if math.abs(ratio - targetRatio) > 0.05 then
+                  include = false
+                end
+              end
+            end
+          end
+        end
+      end
+      
+      if include then
+        table.insert(filteredWallpapers, wallpaper)
+      end
+    end
+
+    wallpapers = filteredWallpapers
     totalPages = normalizeTotalPages(lastPage)
     if page > totalPages then
       page = totalPages

--- a/wallhaven/plugin.toml
+++ b/wallhaven/plugin.toml
@@ -1,6 +1,6 @@
 id = "noctalia/wallhaven"
 name = "Wallhaven"
-version = "1.0.7"
+version = "1.0.8"
 plugin_api = 3
 author = "noctalia"
 license = "MIT"


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Wallhaven API reject list of ratios. Send landscape instead for wide query. Add client-side aspect ratio check to filter returned data exactly.

## Motivation

Wallhaven API reject ratio list on search with space. API also return wrong ratios. User see zero results or incorrect images.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [ ] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [ ] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
