### PR TITLE
docs(timer): update README to document bar widget and desktop widget

### DIFF
--- a/timer/README.md
+++ b/timer/README.md
@@ -1,22 +1,48 @@
 # Timer
 
-Timer adds a desktop countdown widget with start, pause, reset, and optional
-progress display.
+Timer offers two independent timer experiences: a bar widget with panel for
+interactive countdown control, and a standalone desktop widget with its own
+built-in start, pause, reset, and progress display.
 
 ## Plugin
 
 | Field | Value |
 | --- | --- |
 | ID | `noctalia/timer` |
-| Entry | Desktop widget: `timer` |
+| Entries | Service: `timer`; bar widget: `bar`; panel: `panel`; desktop widget: `desktop` |
 
-## Usage
+## Bar Widget and Panel
 
-Add the `timer` desktop widget from Noctalia's desktop-widget editor. The widget
-counts down from the configured duration, can be paused and reset, and sends a
-notification when the countdown reaches zero.
+The headless `timer` service owns countdown logic and state. The `bar` widget
+and `panel` communicate with the service through shared plugin state.
+
+Add the `bar` bar widget to your bar. It displays an hourglass icon when idle,
+or the formatted countdown when running. Click the widget to open the timer
+panel for duration input and controls. When the timer completes, clicking the
+bar widget resets it.
+
+On vertical bars, the widget shows an hourglass with the time as a tooltip.
+On horizontal bars, the widget shows the hourglass and countdown side by side,
+with an option to hide the countdown when idle.
+
+## Desktop Widget
+
+Add the `desktop` desktop widget from Noctalia's desktop-widget editor. The
+widget counts down from the configured duration, can be paused and reset, and
+sends a notification when the countdown reaches zero.
+
+The desktop widget manages its own state independently and does not interact
+with the bar widget or service.
 
 ## Settings
+
+### Bar Widget
+
+| Setting | Type | Default | Description |
+| --- | --- | --- | --- |
+| `show_idle_on_horizontal` | `bool` | `true` | Shows or hides the countdown on horizontal bars when idle. |
+
+### Desktop Widget
 
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -26,5 +52,5 @@ notification when the countdown reaches zero.
 
 ## Notes
 
-This plugin is also a reference implementation for `[[desktop_widget]]` entries
-and Noctalia's declarative `ui.*` widget tree.
+This plugin is a reference implementation for `[[desktop_widget]]` entries,
+`[[widget]]` bar widget entries, and Noctalia's declarative `ui.*` widget tree.


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

The README only documented the desktop widget entry, but the timer plugin now has a bar widget, panel, and service entries. This update documents all entries and their settings.

## Motivation

When doing my PR to add the bar widget to the timer, I completely forgot to update the README.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Refactoring
- [ ] Build / packaging

## Related Issue

None

## Testing

Not applicable. Documentation-only change.

## Manual Coverage

Not applicable. Documentation-only change.

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I self-reviewed the changes.
- [ ] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
