### PR TITLE
fix(bitwarden): copy mimetype compatibility

### DIFF
--- a/bitwarden/plugin.toml
+++ b/bitwarden/plugin.toml
@@ -2,7 +2,7 @@
 
 id = "noctalia/bitwarden"
 name = "Bitwarden"
-version = "1.0.0"
+version = "1.0.1"
 plugin_api = 8
 author = "noctalia"
 license = "MIT"

--- a/bitwarden/service.luau
+++ b/bitwarden/service.luau
@@ -394,7 +394,7 @@ local function copySecret(value, notifyKey)
   if type(value) ~= "string" or value == "" then
     return false
   end
-  noctalia.copyToClipboard(value, "text/plain")
+  noctalia.copyToClipboard(value, "text/plain;charset=utf-8")
   scheduleClipboardClear(value)
   if cfg("notify_on_copy") ~= false then
     noctalia.notify(noctalia.tr("title"), noctalia.tr(notifyKey or "copied"))
@@ -874,7 +874,7 @@ function update()
     if pendingClear.ticksLeft <= 0 then
       local current = noctalia.clipboardText()
       if current == pendingClear.text then
-        noctalia.copyToClipboard("", "text/plain")
+        noctalia.copyToClipboard("", "text/plain;charset=utf-8")
       end
       pendingClear = nil
     end


### PR DESCRIPTION
## Summary

Changed `noctalia.copyToClipboard(value, "text/plain")` to `noctalia.copyToClipboard(value, "text/plain;charset=utf-8")`.

## Motivation

`noctalia.copyToClipboard(value, "text/plain;charset=utf-8")` has better compatibility.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [x] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
