### PR TITLE
Declare ui.markdown and plugin API 20 props

### DIFF
--- a/noctalia.d.luau
+++ b/noctalia.d.luau
@@ -359,6 +359,11 @@ declare ui: {
   row: UiCtor,
   box: UiCtor,
   label: UiCtor,
+  -- Markdown block (plugin_api >= 20). Renders the text prop (headings,
+  -- lists, code blocks, tables) as a read-only block. The host re-parses
+  -- only when text or the surface scale changes, so streaming re-renders
+  -- with unchanged text are cheap.
+  markdown: UiCtor,
   glyph: UiCtor,
   image: UiCtor,
   separator: UiCtor,
@@ -366,10 +371,20 @@ declare ui: {
   progress: UiCtor,
   button: UiCtor,
   graph: UiCtor,
+  -- input also takes submitOnEnter (plugin_api >= 20): in a multiline
+  -- input, Enter then fires onSubmit and Shift+Enter inserts the newline
+  -- instead; Ctrl+Enter always submits. Default off (Enter inserts a
+  -- newline).
   input: UiCtor,
   select: UiCtor,
   slider: UiCtor,
   toggle: UiCtor,
+  -- scroll also takes (plugin_api >= 20): stickToBottom (bool) keeps the
+  -- view pinned to the bottom while content grows, until the user scrolls
+  -- away; onScroll receives (offset, maxOffset), both delivered as
+  -- strings; scrollToBottomRev (number) jumps to the bottom on the first
+  -- render that sees it and again whenever the value changes, applied
+  -- after the next layout pass so it reaches the new extent.
   scroll: UiCtor,
   -- Drag and drop (plugin panels only, plugin_api >= 5). dragSource props:
   -- dragType/payload (required strings), enabled, tooltip, previewAncestor


### PR DESCRIPTION
Companion to noctalia-dev/noctalia#3327 (plugin API 20). Requested in
that PR's review: `noctalia.d.luau` did not declare `ui.markdown`.

Adds `markdown` to the `declare ui` table and documents the new
API-20-gated props with the file's existing comment conventions:

- `ui.markdown`: renders the `text` prop (headings, lists, code
  blocks, tables) as a read-only block. The host re-parses only when
  the text or the surface scale changes, so streaming re-renders with
  unchanged text are cheap.
- `ui.input` `submitOnEnter`: chat-style submit for multiline inputs.
  Enter fires `onSubmit`, Shift+Enter inserts the newline, Ctrl+Enter
  still submits. Default off, existing behavior unchanged.
- `ui.scroll` `stickToBottom` / `onScroll` / `scrollToBottomRev`:
  follow-scroll while content grows, an `(offset, maxOffset)` scroll
  callback, and a deferred jump-to-bottom trigger.

Tested live by a chat panel plugin (streaming markdown, follow-scroll,
Enter-to-send composer) against a shell carrying the #3327 patches.