### PR TITLE
fix(notes): limit characters in titles to prevent it from going through the pin and delete buttons

### DIFF
--- a/notes/panel.luau
+++ b/notes/panel.luau
@@ -204,7 +204,7 @@ local function listRow(file)
   -- Both row states keep the same leading text button so the row height (set
   -- by the text-button tier) never changes when the confirm controls swap in.
   local displayName = displayName(file)
-  local truncated = truncateText(displayName, 38)
+  local truncated = truncateText(displayName, 34)
   local title = {
     text = truncated,
     variant = "ghost",

--- a/notes/panel.luau
+++ b/notes/panel.luau
@@ -192,15 +192,25 @@ local function togglePin(file)
   render()
 end
 
+local function truncateText(text, maxLength)
+  if #text <= maxLength then
+    return text
+  end
+  return text:sub(1, maxLength - 3) .. "..."
+end
+
 local function listRow(file)
   local pinned = pins[file] == true
   -- Both row states keep the same leading text button so the row height (set
   -- by the text-button tier) never changes when the confirm controls swap in.
+  local displayName = displayName(file)
+  local truncated = truncateText(displayName, 38)
   local title = {
-    text = displayName(file),
+    text = truncated,
     variant = "ghost",
     contentAlign = "start",
     flexGrow = 1,
+    tooltip = displayName,
     onClick = function()
       openNote(file)
     end,

--- a/notes/plugin.toml
+++ b/notes/plugin.toml
@@ -1,6 +1,6 @@
 id = "noctalia/notes"
 name = "Notes"
-version = "1.0.3"
+version = "1.0.4"
 plugin_api = 9
 author = "noctalia"
 license = "MIT"


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->

## Motivation

No more overflowing titles and added tooltip for showing full title

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

Before:
<img width="650" height="419" alt="image" src="https://github.com/user-attachments/assets/62a80991-ee86-4cf4-b129-c892d3f7b17a" />
<img width="650" height="419" alt="image" src="https://github.com/user-attachments/assets/82a2311b-e97d-4614-8b2c-e5c2ed5e4faa" />
---
After:
<img width="650" height="419" alt="Screenshot from 2026-07-31 18-58-57" src="https://github.com/user-attachments/assets/f11f0048-b209-43f9-9c47-fabb447d4e0e" />
<img width="650" height="419" alt="image" src="https://github.com/user-attachments/assets/249cd8e1-ff68-4960-82f8-8148b6a848ef" />
<img width="650" height="419" alt="image" src="https://github.com/user-attachments/assets/c7b55db6-f3f6-4b1c-94c9-7567a0d1083f" />

## Checklist

- [ ] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [ ] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
