### PR TITLE
fix(screen_recorder): add jay as a portal backend

### DIFF
--- a/screen_recorder/README.md
+++ b/screen_recorder/README.md
@@ -15,10 +15,7 @@ Control Center.
 
 Install `gpu-screen-recorder` on `PATH`, or install the Flatpak app
 `com.dec05eba.gpu_screen_recorder`. Portal capture also requires
-`xdg-desktop-portal` and one supported backend, such as
-`xdg-desktop-portal-wlr`, `xdg-desktop-portal-hyprland`,
-`xdg-desktop-portal-gnome`, `xdg-desktop-portal-kde`, `niri-screenshare`,
-or `jay`.
+`xdg-desktop-portal` with any backend that provides the ScreenCast interface.
 
 - **[gpu-screen-recorder](https://git.dec05eba.com/gpu-screen-recorder/about/)** — Hardware-accelerated screen recording
 

--- a/screen_recorder/README.md
+++ b/screen_recorder/README.md
@@ -17,8 +17,8 @@ Install `gpu-screen-recorder` on `PATH`, or install the Flatpak app
 `com.dec05eba.gpu_screen_recorder`. Portal capture also requires
 `xdg-desktop-portal` and one supported backend, such as
 `xdg-desktop-portal-wlr`, `xdg-desktop-portal-hyprland`,
-`xdg-desktop-portal-gnome`, `xdg-desktop-portal-kde`, or
-`niri-screenshare`.
+`xdg-desktop-portal-gnome`, `xdg-desktop-portal-kde`, `niri-screenshare`,
+or `jay`.
 
 - **[gpu-screen-recorder](https://git.dec05eba.com/gpu-screen-recorder/about/)** — Hardware-accelerated screen recording
 

--- a/screen_recorder/plugin.toml
+++ b/screen_recorder/plugin.toml
@@ -12,7 +12,7 @@
 
 id = "noctalia/screen_recorder"
 name = "Screen Recorder"
-version = "1.2.1"
+version = "1.2.2"
 plugin_api = 3
 author = "noctalia"
 license = "MIT"

--- a/screen_recorder/recorder_service.luau
+++ b/screen_recorder/recorder_service.luau
@@ -316,7 +316,7 @@ local function checkPortalsIfNeededAsync(sourceOverride, callback)
         return
     end
 
-    local pending = 6
+    local pending = 7
     local hasPortal = false
     local hasBackend = false
 
@@ -352,6 +352,8 @@ local function checkPortalsIfNeededAsync(sourceOverride, callback)
     queue("backend", "xdg-desktop-portal-kde ")
     -- niri-screenshare (or similarly named) ScreenCast backends
     queue("backend", "niri-screenshare ")
+    -- jay's built-in portal (embedded in the compositor process)
+    queue("backend", "jay ")
 end
 
 -- ── Recording controls ───────────────────────────────────────────────────

--- a/screen_recorder/recorder_service.luau
+++ b/screen_recorder/recorder_service.luau
@@ -316,44 +316,18 @@ local function checkPortalsIfNeededAsync(sourceOverride, callback)
         return
     end
 
-    local pending = 7
-    local hasPortal = false
-    local hasBackend = false
-
-    local function finish(kind, matched)
-        if matched then
-            if kind == "portal" then
-                hasPortal = true
-            elseif kind == "backend" then
-                hasBackend = true
-            end
-        end
-
-        pending -= 1
-        if pending == 0 then
-            log(`portal check: portal={hasPortal} backend={hasBackend}`)
-            callback(hasPortal and hasBackend)
-        end
+    -- Only verify xdg-desktop-portal itself is running. Which backend services
+    -- ScreenCast (wlr, hyprland, gnome, kde, umbriel, jay, niri-screenshare,
+    -- …) is the portal's problem to route; if none can, gpu-screen-recorder
+    -- surfaces the error and logGsrTail echoes it.
+    local ok = noctalia.processMatches(function(matched)
+        log(`portal check: portal={matched}`)
+        callback(matched)
+    end, "xdg-desktop-portal ")
+    if not ok then
+        log("portal check: processMatches unavailable")
+        callback(false)
     end
-
-    local function queue(kind, token)
-        local ok = noctalia.processMatches(function(matched)
-            finish(kind, matched)
-        end, token)
-        if not ok then
-            finish(kind, false)
-        end
-    end
-
-    queue("portal", "xdg-desktop-portal ")
-    queue("backend", "xdg-desktop-portal-wlr ")
-    queue("backend", "xdg-desktop-portal-hyprland ")
-    queue("backend", "xdg-desktop-portal-gnome ")
-    queue("backend", "xdg-desktop-portal-kde ")
-    -- niri-screenshare (or similarly named) ScreenCast backends
-    queue("backend", "niri-screenshare ")
-    -- jay's built-in portal (embedded in the compositor process)
-    queue("backend", "jay ")
 end
 
 -- ── Recording controls ───────────────────────────────────────────────────


### PR DESCRIPTION

## Summary

Adding jay compositor as a backend for the screen recorder plugin. It works out of the box with gpu-screen-recorder but Noctalia wasn't recognizing it before.

## Type of Change

- [X] Bug fix

## Testing
Tested the plugin on Jay and seems to work well with the built-in screenshare portal.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [X] Tested on another compositor: Jay
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Additional Notes

I asked before in the discord if it was ok to post this small patch. Please let me know if I messed up in any way though. This patch seems to work just fine with screenrecording in Jay. Thanks :)
