### PR TITLE
fix(timer): preserve entered duration on reopening panel

### DIFF
--- a/timer/panel.luau
+++ b/timer/panel.luau
@@ -121,6 +121,7 @@ end
 function onOpen(_context)
   STATE = noctalia.state.get("timer.state")
   remaining = noctalia.state.get("timer.remaining")
+  formattedTime = noctalia.state.get("timer.formattedTime") or "0"
   resetInputDigits()
   render()
 end

--- a/timer/panel.luau
+++ b/timer/panel.luau
@@ -113,7 +113,7 @@ local function resetInputDigits()
   if remaining == 0 then
     inputDigits = ""
   else
-    inputDigits = tostring(remaining)
+    inputDigits = formattedTime
   end
   updateInputDigits()
 end

--- a/timer/plugin.toml
+++ b/timer/plugin.toml
@@ -12,7 +12,7 @@
 
 id = "noctalia/timer"
 name = "Timer"
-version = "1.2.0"
+version = "1.2.1"
 plugin_api = 3
 author = "noctalia"
 license = "MIT"


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Changed timer panel to restore using `formattedTime` instead of raw `remaining` seconds on reopening panel.

## Motivation

Previously the remaining raw seconds was passed to `inputDigits` as string. On reopening the panel that string was treated as HHMMSS and converted to seconds again thus changing the time the timer starts from after reopening the panel. Passing `formattedTime` which is already in HHMMSS format fixes the issue. 

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #30

## Testing
Type a duration (e.g. "400") without starting, close panel by clicking away, reopen -> input now shows the correct value instead of the converted seconds.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [x] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->