### PR TITLE
docs(types): declare panel context menu API

### DIFF
--- a/noctalia.d.luau
+++ b/noctalia.d.luau
@@ -65,6 +65,31 @@ export type WallpaperMask = {
   wallpaperPath: string,
 }
 
+export type PanelContextMenuAction = {
+  kind: "item"?, -- may be omitted for action rows
+  id: string,
+  label: string,
+  enabled: boolean?, -- defaults to true
+}
+
+export type PanelContextMenuHeader = {
+  kind: "header",
+  label: string,
+}
+
+export type PanelContextMenuSeparator = {
+  kind: "separator",
+}
+
+export type PanelContextMenuItem = PanelContextMenuAction | PanelContextMenuHeader | PanelContextMenuSeparator
+
+export type PanelContextMenuRequest = {
+  items: { PanelContextMenuItem },
+  onActivate: string,
+  context: (string | number | boolean)?,
+  maxVisible: number?, -- defaults to 12, valid range 1..30
+}
+
 -- A tooltip row: { key, value } or the positional array form { key, value }.
 export type TooltipRow = { key: string?, value: string? }
 
@@ -431,6 +456,10 @@ declare desktopWidget: {
 declare panel: {
   render: (tree: UiNode) -> (),
   close: () -> (),
+  -- Opens a native menu at the originating direct pointer callback. Returns
+  -- false outside a live pointer callback. onActivate receives
+  -- (actionId, context) in the panel script. Requires plugin_api >= 28.
+  openContextMenu: (request: PanelContextMenuRequest) -> boolean,
   setWantsSecondTicks: (wants: boolean) -> (),
   setNeedsFrameTick: (needs: boolean) -> (),
 }


### PR DESCRIPTION
## Summary

- declare the API 28 panel context-menu request and item types
- expose `panel.openContextMenu(request)` in `noctalia.d.luau`

## Motivation

Keep the official Luau declarations in sync with the native panel context-menu API proposed in noctalia-dev/noctalia#3906.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

- Companion to https://github.com/noctalia-dev/noctalia/pull/3906
- Implements the type-declaration follow-up requested for https://github.com/noctalia-dev/noctalia/issues/3899

## Testing

- `git diff --check`

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

Not applicable: this PR only updates Luau declarations.

## Screenshots / Videos

Not applicable.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [x] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.

## Additional Notes

This declaration targets plugin API 28 and depends on the core API in noctalia-dev/noctalia#3906.