### PR TITLE
screen_recorder: add encoder setting with CPU fallback

### DIFF
--- a/screen_recorder/README.md
+++ b/screen_recorder/README.md
@@ -67,6 +67,7 @@ Replay controls are available only when `replay_enabled` is true.
 | `replay_duration` | `int` | `30` | Replay buffer duration in seconds. |
 | `replay_storage` | `select` | `ram` | Stores replay data in RAM or on disk. |
 | `restore_portal` | `bool` | `false` | Asks GPU Screen Recorder to restore the portal session. |
+| `encoder` | `select` | `gpu` | `gpu` uses hardware encoding with a CPU fallback if it fails at runtime; `cpu` skips the hardware probe entirely, for GPUs with no video encoder at all (e.g. Asahi/Apple Silicon, some VMs). |
 
 ## IPC
 

--- a/screen_recorder/plugin.toml
+++ b/screen_recorder/plugin.toml
@@ -12,7 +12,7 @@
 
 id = "noctalia/screen_recorder"
 name = "Screen Recorder"
-version = "1.2.2"
+version = "1.3.0"
 plugin_api = 3
 author = "noctalia"
 license = "MIT"
@@ -184,6 +184,18 @@ type = "bool"
 label_key = "settings.restore_portal.label"
 default = false
 advanced = true
+
+[[setting]]
+key = "encoder"
+type = "select"
+label_key = "settings.encoder.label"
+description_key = "settings.encoder.description"
+default = "gpu"
+advanced = true
+options = [
+  { value = "gpu", label_key = "settings.encoder.options.gpu" },
+  { value = "cpu", label_key = "settings.encoder.options.cpu" },
+]
 
 # Headless background service: owns the recording / replay logic, runs for the
 # whole session, and bridges the "command" / "status" state channels.

--- a/screen_recorder/recorder_service.luau
+++ b/screen_recorder/recorder_service.luau
@@ -197,6 +197,17 @@ local function buildResolutionFlag()
     return if res ~= "original" then `-s {res}` else ""
 end
 
+-- "-fallback-cpu-encoding yes" is always included so a hardware encoder that
+-- fails at runtime (e.g. unsupported codec, driver bug) degrades to software
+-- encoding instead of aborting the recording. "-encoder cpu" additionally
+-- skips the hardware probe entirely, which is required on GPUs with no VAAPI/
+-- NVENC encoder at all (Asahi/Apple Silicon, some VMs) — probing there always
+-- fails and just delays startup.
+local function buildEncoderFlags()
+    local forceCpu = if cfg("encoder") == "cpu" then " -encoder cpu" else ""
+    return `-fallback-cpu-encoding yes{forceCpu}`
+end
+
 -- Capture modes a caller may request. An IPC override outside this set is
 -- discarded so an arbitrary payload can never reach the gpu-screen-recorder
 -- command line.
@@ -270,8 +281,9 @@ local function buildRecordCommand(focusedOutputName, sourceOverride)
     local restore = if cfg("restore_portal") then "-restore-portal-session yes" else ""
     local audioFlags = buildAudioFlags()
     local resFlag = buildResolutionFlag()
+    local encoderFlags = buildEncoderFlags()
 
-    local flags = `-w {source} -f {fps} -k {codec} {audioFlags} -bm qp -ffmpeg-video-opts qp={qp} -cursor {cursor} -cr {cr} {resFlag} {restore} -v no -o "{outputPath}"`
+    local flags = `-w {source} -f {fps} -k {codec} {audioFlags} -bm qp -ffmpeg-video-opts qp={qp} -cursor {cursor} -cr {cr} {resFlag} {restore} {encoderFlags} -v no -o "{outputPath}"`
 
     log(`starting recording: mode={selectedVideoSource(sourceOverride)} target={source} output={outputPath} flags=[{flags}]`)
 
@@ -297,8 +309,9 @@ local function buildReplayCommand(focusedOutputName, sourceOverride)
     local restore = if cfg("restore_portal") then "-restore-portal-session yes" else ""
     local audioFlags = buildAudioFlags()
     local resFlag = buildResolutionFlag()
+    local encoderFlags = buildEncoderFlags()
 
-    local flags = `-w {source} -c mp4 -f {fps} -k {codec} {audioFlags} -bm qp -ffmpeg-video-opts qp={qp} -cursor {cursor} -cr {cr} {resFlag} -r {duration} -replay-storage {storage} {restore} -v no -o "{dir}"`
+    local flags = `-w {source} -c mp4 -f {fps} -k {codec} {audioFlags} -bm qp -ffmpeg-video-opts qp={qp} -cursor {cursor} -cr {cr} {resFlag} -r {duration} -replay-storage {storage} {restore} {encoderFlags} -v no -o "{dir}"`
 
     log(`starting replay buffer: mode={selectedVideoSource(sourceOverride)} target={source} dir={dir} flags=[{flags}]`)
 

--- a/screen_recorder/translations/en.json
+++ b/screen_recorder/translations/en.json
@@ -47,6 +47,14 @@
       "description": "Defaults to ~/Videos/Recordings when empty",
       "label": "Output Directory"
     },
+    "encoder": {
+      "description": "CPU encoding always works but uses more power; GPU encoding requires a working hardware video encoder (VAAPI/NVENC) and isn't available on some systems (e.g. Asahi/Apple Silicon GPUs, some VMs)",
+      "label": "Encoder",
+      "options": {
+        "cpu": "CPU (software)",
+        "gpu": "GPU (hardware)"
+      }
+    },
     "filename_pattern": {
       "description": "Date-format pattern without extension; use %s for Unix timestamp",
       "label": "Filename Pattern"


### PR DESCRIPTION
## Summary

Adds an `encoder` setting (`gpu` / `cpu`, default `gpu`) to the Screen Recorder
plugin, and always passes `-fallback-cpu-encoding yes` to `gpu-screen-recorder`
for both recording and the replay buffer.

## Motivation

On GPUs with no hardware video encoder at all (Asahi/Apple Silicon GPUs, some
VMs), `gpu-screen-recorder`'s VAAPI probe fails outright:

```
gsr error: gsr_get_supported_video_codecs_vaapi: vaInitialize failed
gsr error: selected video codec h264 is not supported by your hardware
```

The recording aborts with no output file, and the plugin currently exposes no
way to force software encoding. `gpu-screen-recorder` already supports this
via `-encoder cpu` / `-fallback-cpu-encoding yes`; the plugin just never wired
it up.

- `-fallback-cpu-encoding yes` is added unconditionally: if a hardware
  encoder fails at runtime for any reason, the recording degrades to software
  encoding instead of aborting. This is a no-op improvement for everyone with
  working hardware encoding.
- `encoder = cpu` additionally skips the hardware probe entirely, for
  hardware where it always fails anyway.

Default stays `gpu` so existing behavior is unchanged for users with a
working hardware encoder.

## Type of Change

- [x] Bug fix
- [x] New feature

## Testing

- `noctalia plugins lint screen_recorder` — 0 errors, 0 warnings
- `python3 .github/workflows/validate-plugins.py --root .` — validated 12 plugin manifest(s)
- Manually verified end-to-end on the hardware this fixes: an Apple M2 MacBook
  running Asahi Linux + niri + Noctalia. Before the fix, starting a recording
  produced the `vaInitialize failed` error above and no output file. After
  setting `encoder = cpu`, a portal-mode recording completed successfully to
  `~/Videos/Recordings`.

## Manual Coverage

- [x] Tested on Niri

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [x] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.

## Additional Notes

Bumped `plugin.toml` version from `1.2.2` to `1.3.0` (new backward-compatible setting).