### PR TITLE
feat(mpvpaper): add control center tile

### DIFF
--- a/mpvpaper/README.md
+++ b/mpvpaper/README.md
@@ -13,7 +13,7 @@ drawn above it.
 | Field | Value |
 | --- | --- |
 | ID | `noctalia/mpvpaper` |
-| Entries | Service: `service`; Panel: `picker`; bar widget: `mpvpaper` |
+| Entries | Service: `service`; Panel: `picker`; bar widget: `mpvpaper`; Shortcut: `shortcut` |
 
 ## Requirements
 
@@ -25,7 +25,7 @@ The plugin works on `wlr-layer-shell` compositors (Niri, Hyprland, Sway, Mango).
 ## Usage
 
 1. Set **Video directory** in the plugin settings (defaults to `~/Videos`).
-2. Add the **Video Wallpaper** bar widget, or open the picker with
+2. Add the **Video Wallpaper** bar widget, the control center shortcut, or open the picker with
 
    ```sh
    noctalia msg panel-toggle noctalia/mpvpaper:picker

--- a/mpvpaper/plugin.toml
+++ b/mpvpaper/plugin.toml
@@ -10,7 +10,7 @@
 
 id = "noctalia/mpvpaper"
 name = "Video Wallpaper"
-version = "1.0.7"
+version = "1.1.0"
 plugin_api = 9
 author = "noctalia"
 license = "MIT"
@@ -135,3 +135,8 @@ entry = "widget.luau"
   type = "glyph"
   label_key = "settings.glyph.label"
   default = "movie"
+
+# Control center shortcut that opens the picker.
+[[shortcut]]
+id = "shortcut"
+entry = "shortcut.luau"

--- a/mpvpaper/shortcut.luau
+++ b/mpvpaper/shortcut.luau
@@ -1,0 +1,13 @@
+--!nonstrict
+-- Tile in the control center that opens the video wallpaper picker.
+
+local function render()
+    shortcut.setLabel("Video Wallpaper")
+    shortcut.setIcon("movie")
+end
+
+render()
+
+function onClick()
+  noctalia.togglePanel("noctalia/mpvpaper:picker")
+end

--- a/mpvpaper/shortcut.luau
+++ b/mpvpaper/shortcut.luau
@@ -2,7 +2,7 @@
 -- Tile in the control center that opens the video wallpaper picker.
 
 local function render()
-    shortcut.setLabel("Video Wallpaper")
+    shortcut.setLabel(noctalia.tr("title"))
     shortcut.setIcon("movie")
 end
 


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
I added a control center tile to the mpvpaper plugin. Someone asked for it in the discord.

## Motivation

<!-- What problem does this solve? -->
Someone asked for it in the discord.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->
No github issue.

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
I added the tile to my control center and it opens the panel.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
<img width="136" height="116" alt="image" src="https://github.com/user-attachments/assets/05fa73c7-6c0b-4fd3-9653-e4bbc47e9472" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [x] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
