### PR TITLE
feat(wallhaven): add control center tile

### DIFF
--- a/wallhaven/README.md
+++ b/wallhaven/README.md
@@ -7,12 +7,12 @@ Browse [Wallhaven](https://wallhaven.cc), download a wallpaper into your Noctali
 | Field | Value |
 | --- | --- |
 | ID | `noctalia/wallhaven` |
-| Entries | Panel: `browser`; bar widget: `wallhaven` |
+| Entries | Panel: `browser`; bar widget: `wallhaven`; shortcut: `shortcut` |
 
 ## Usage
 
 1. Enable the plugin in Settings → Plugins.
-2. Add the `wallhaven` bar widget, or run:
+2. Add the `wallhaven` bar widget, the control center shortcut, or run:
 
    ```sh
    noctalia msg panel-toggle noctalia/wallhaven:browser

--- a/wallhaven/plugin.toml
+++ b/wallhaven/plugin.toml
@@ -40,3 +40,7 @@ entry = "wallhaven.luau"
   type = "glyph"
   label_key = "settings.glyph.label"
   default = "photo"
+
+[[shortcut]]
+id = "shortcut"
+entry = "shortcut.luau"

--- a/wallhaven/plugin.toml
+++ b/wallhaven/plugin.toml
@@ -1,6 +1,6 @@
 id = "noctalia/wallhaven"
 name = "Wallhaven"
-version = "1.0.10"
+version = "1.1.0"
 plugin_api = 9
 author = "noctalia"
 license = "MIT"

--- a/wallhaven/shortcut.luau
+++ b/wallhaven/shortcut.luau
@@ -1,0 +1,13 @@
+--!nonstrict
+-- Control center tile that opens the Wallhaven browser panel.
+
+local function render()
+    shortcut.setLabel(noctalia.tr("title"))
+    shortcut.setIcon("photo")
+end
+
+render()
+
+function onClick()
+    noctalia.togglePanel("noctalia/wallhaven:browser")
+end


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
I added a control center tile for the wallhaven plugin that opens the panel.

## Motivation

<!-- What problem does this solve? -->
A lot of people are complaining that there is no control center tile in most plugins.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->
No github issue.

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
I added the tile to my control center and it opens the panel.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
<img width="131" height="108" alt="image" src="https://github.com/user-attachments/assets/f7a1003e-baf1-410a-b14e-ee580304622f" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [x] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
