### PR TITLE
chore(wallpaper_depth): pip install --no-user

### DIFF
--- a/wallpaper_depth/depth_helper.py
+++ b/wallpaper_depth/depth_helper.py
@@ -132,6 +132,7 @@ def setup(data_dir: Path) -> None:
                 "install",
                 "--disable-pip-version-check",
                 "--no-input",
+                "--no-user",
                 "--only-binary=:all:",
                 *PACKAGES,
             ],


### PR DESCRIPTION
In a venv the pip install will fail if the user option is set to true. This may happen if for example it is set in the users ~/.config/pip/pip.conf. Using the --no-user option will override such a config file option.

<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Added `--no-user` option o the `pip install` incantation.
This avoids an edge case bug that could cause the `pip install` to fail.

## Motivation

Wallpaper Depth setup failed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

```bash
~/.local/state/noctalia/plugins/data/noctalia/wallpaper_depth/runtime/.venv/bin/python -m pip install --disable-pip-version-check --no-input --no-user --only-binary=:all: numpy==2.4.2 onnxruntime==1.28.0 Pillow==12.3.0
```

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: Mango
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [x] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.

