### PR TITLE
feat(screen_recorder): configurable bar glyph per state

### DIFF
--- a/screen_recorder/README.md
+++ b/screen_recorder/README.md
@@ -63,6 +63,11 @@ Replay controls are available only when `replay_enabled` is true.
 | `color_range` | `select` | `limited` | Uses limited or full color range. |
 | `copy_to_clipboard` | `bool` | `false` | Copies the saved recording URI to the clipboard. |
 | `hide_inactive` | `bool` | `false` | Hides the bar widget while idle. |
+| `glyph_unavailable` | `glyph` | `video-off` | Bar glyph when gpu-screen-recorder is not installed. |
+| `glyph_idle` | `glyph` | `video` | Bar glyph when idle. |
+| `glyph_pending` | `glyph` | `video` | Bar glyph while a recording or replay buffer is starting. |
+| `glyph_recording` | `glyph` | `video` | Bar glyph while recording. |
+| `glyph_replaying` | `glyph` | `repeat` | Bar glyph while the replay buffer is running. |
 | `replay_enabled` | `bool` | `false` | Enables replay-buffer controls. |
 | `replay_duration` | `int` | `30` | Replay buffer duration in seconds. |
 | `replay_storage` | `select` | `ram` | Stores replay data in RAM or on disk. |

--- a/screen_recorder/plugin.toml
+++ b/screen_recorder/plugin.toml
@@ -144,6 +144,42 @@ type = "bool"
 label_key = "settings.hide_inactive.label"
 default = false
 
+# Bar glyph per state. Defaults are the values the widget previously hardcoded,
+# so this changes nothing until someone sets one. Tabler carries filled variants
+# of most outline icons, so "video-filled" is the usual pick for `recording` if
+# you want the active state to read as solid rather than outline.
+[[setting]]
+key = "glyph_unavailable"
+type = "glyph"
+label_key = "settings.glyph_unavailable.label"
+description_key = "settings.glyph_unavailable.description"
+default = "video-off"
+
+[[setting]]
+key = "glyph_idle"
+type = "glyph"
+label_key = "settings.glyph_idle.label"
+default = "video"
+
+[[setting]]
+key = "glyph_pending"
+type = "glyph"
+label_key = "settings.glyph_pending.label"
+description_key = "settings.glyph_pending.description"
+default = "video"
+
+[[setting]]
+key = "glyph_recording"
+type = "glyph"
+label_key = "settings.glyph_recording.label"
+default = "video"
+
+[[setting]]
+key = "glyph_replaying"
+type = "glyph"
+label_key = "settings.glyph_replaying.label"
+default = "repeat"
+
 [[setting]]
 key = "replay_enabled"
 type = "bool"

--- a/screen_recorder/plugin.toml
+++ b/screen_recorder/plugin.toml
@@ -12,7 +12,7 @@
 
 id = "noctalia/screen_recorder"
 name = "Screen Recorder"
-version = "1.2.2"
+version = "1.2.3"
 plugin_api = 3
 author = "noctalia"
 license = "MIT"

--- a/screen_recorder/recorder.luau
+++ b/screen_recorder/recorder.luau
@@ -19,6 +19,17 @@ local function send(action)
     noctalia.state.set("command", { action = action, focusedOutputName = noctalia.focusedOutputName() })
 end
 
+-- Glyph per state, configurable. The fallback passed to each lookup is the
+-- value this widget used before the settings existed, so an unset or blank
+-- glyph keeps the previous appearance.
+local function glyphFor(key, fallback)
+    local configured = noctalia.getConfig(key)
+    if type(configured) == "string" and configured ~= "" then
+        return configured
+    end
+    return fallback
+end
+
 local function applyStatus(status)
     if type(status) == "table" then
         state = status.state or "idle"
@@ -28,29 +39,29 @@ local function applyStatus(status)
     local hideInactive = noctalia.getConfig("hide_inactive")
 
     if not available then
-        barWidget.setGlyph("video-off")
+        barWidget.setGlyph(glyphFor("glyph_unavailable", "video-off"))
         barWidget.setGlyphColor("on_surface_variant")
         barWidget.setVisible(not hideInactive)
         return
     end
 
     if state == "recording" then
-        barWidget.setGlyph("video")
+        barWidget.setGlyph(glyphFor("glyph_recording", "video"))
         barWidget.setGlyphColor("error")
         barWidget.setColor("error")
         barWidget.setVisible(true)
     elseif table.find(PENDING_STATES, state) then
-        barWidget.setGlyph("video")
+        barWidget.setGlyph(glyphFor("glyph_pending", "video"))
         barWidget.setGlyphColor("primary")
         barWidget.setColor("primary")
         barWidget.setVisible(true)
     elseif state == "replaying" then
-        barWidget.setGlyph("repeat")
+        barWidget.setGlyph(glyphFor("glyph_replaying", "repeat"))
         barWidget.setGlyphColor("secondary")
         barWidget.setColor("secondary")
         barWidget.setVisible(true)
     else
-        barWidget.setGlyph("video")
+        barWidget.setGlyph(glyphFor("glyph_idle", "video"))
         barWidget.setGlyphColor("on_surface")
         barWidget.setVisible(not hideInactive)
     end

--- a/screen_recorder/translations/en.json
+++ b/screen_recorder/translations/en.json
@@ -54,6 +54,23 @@
     "frame_rate": {
       "label": "Frame Rate"
     },
+    "glyph_idle": {
+      "label": "Glyph: Idle"
+    },
+    "glyph_pending": {
+      "label": "Glyph: Starting",
+      "description": "Shown while a recording or replay buffer is starting."
+    },
+    "glyph_recording": {
+      "label": "Glyph: Recording"
+    },
+    "glyph_replaying": {
+      "label": "Glyph: Replay Buffer"
+    },
+    "glyph_unavailable": {
+      "label": "Glyph: Unavailable",
+      "description": "Shown when gpu-screen-recorder is not installed."
+    },
     "hide_inactive": {
       "label": "Hide Widget When Idle"
     },


### PR DESCRIPTION
## Summary

The `screen_recorder` bar widget hardcodes its glyph for each state, so changing one means editing `recorder.luau` and losing it on the next update. This adds five settings, one per state the widget renders:

| setting | default | when |
|---|---|---|
| `glyph_unavailable` | `video-off` | gpu-screen-recorder not installed |
| `glyph_idle` | `video` | ready |
| `glyph_pending` | `video` | recording or replay buffer starting |
| `glyph_recording` | `video` | recording |
| `glyph_replaying` | `repeat` | replay buffer running |

Every default is the glyph that state already used, and an unset or empty value falls back to the same, so **this is a no-op until someone sets one**. Colours are untouched: recording stays `error`, pending `primary`, replaying `secondary`.

## Motivation

Idle and recording both render `video` and differ only by colour. On a busy bar that is easy to miss, and it carries no signal at all for a red/green colour blind user.

Tabler ships filled variants of most outline icons, so `glyph_recording = "video-filled"` gives a solid camera while recording against an outline one at rest — distinguishable by shape as well as tint.

I deliberately left that out of the defaults. Changing what everyone sees is a taste call rather than a fix, and this PR is only about making it reachable.

## Type of Change

- [x] New feature

## Related Issue

None.

## Testing

- `noctalia plugins lint screen_recorder` — 0 errors, 0 warnings
- `python3 .github/workflows/validate-plugins.py` — validated 12 plugin manifest(s), exit 0
- Loaded against `noctalia-git 5.0.0.r5339` — plugin loads with 3 entries, no config warnings with `glyph_recording = "video-filled"` set via `[plugin_settings."noctalia/screen_recorder"]`
- Start/stop exercised via `noctalia msg plugin noctalia/screen_recorder:service all toggle`; state transitions and the existing settings (codec, qp, audio source, cursor) behave as before
- With no glyph settings set, the widget renders exactly as it did before the change

`translations/en.json` carries the new labels only, per the README — other locales are left to Noctalia Translate.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

Tested on niri 26.04, two outputs (3440x1440 + 2560x1440), bar at top. Not tested on other compositors, other bar positions, or non-default scaling — the change is a per-state glyph name lookup with unchanged fallbacks, so it should be independent of all three, but I have not verified that.
