### PR TITLE
feat(wallhaven): persist current browse page across panel reopens

### DIFF
--- a/wallhaven/panel.luau
+++ b/wallhaven/panel.luau
@@ -735,7 +735,6 @@ end
 
 function onOpen(_context)
   normalizePurityFilters()
-  page = 1
   fetchWallpapers()
 end
 

--- a/wallhaven/plugin.toml
+++ b/wallhaven/plugin.toml
@@ -1,6 +1,6 @@
 id = "noctalia/wallhaven"
 name = "Wallhaven"
-version = "1.1.0"
+version = "1.2.0"
 plugin_api = 9
 author = "noctalia"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Preserves the current browse page index (`page`) in the Wallhaven browser panel across panel close/reopen cycles and source navigation.
- Removes the unconditional `page = 1` reset in `onOpen(_context)` in `wallhaven/panel.luau`.
- Ensures pagination continues to reset to page 1 whenever a new search query is submitted or filters/resolutions are changed.

## Motivation

In Noctalia v4, closing/reopening the wallpaper chooser or switching sources reset search results back to page 1. This ports the v4 fix to Noctalia v5 Luau runtime so users do not lose their current pagination position when toggling the Wallhaven panel.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

- Validated JSON syntax across all translation manifests (`wallhaven/translations/*.json`) via `jq empty`.
- Verified strict diff isolation scoped only to `wallhaven/panel.luau`.

## Manual Coverage

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: mangowm
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

N/A (behavioral pagination state persistence)

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [x] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.

## Additional Notes

N/A