### PR TITLE
feat: add hover, corner radius to the notes panel

### DIFF
--- a/notes/panel.luau
+++ b/notes/panel.luau
@@ -521,11 +521,6 @@ end
 
 function onRowHover(state, key)
   hoveredKey = (state == "true") and key or nil
-  -- if state == "true" then
-  --   hoveredKey = file
-  -- elseif hoveredKey == file then
-  --   hoveredKey = nil
-  -- end
   render()
 end
 

--- a/notes/panel.luau
+++ b/notes/panel.luau
@@ -21,6 +21,8 @@ local idleTicks = 0
 local pendingDelete = nil -- filename awaiting the second (confirm) click
 local sortByDate = false
 local pins = {} -- filename -> true; persisted in a sidecar next to the notes
+local hoveredKey = nil
+local cornerRadiusScale = 1.0
 
 local render
 
@@ -194,18 +196,34 @@ end
 
 local function listRow(file)
   local pinned = pins[file] == true
+  local isHovered = hoveredKey == file
   -- Label elides natively with maxLines=1; the row wrapper supplies the click target.
   local titleChildren = {
-    ui.label({ text = displayName(file), maxLines = 1, flexGrow = 1 }),
+    ui.label({
+      text = displayName(file),
+      maxLines = 1,
+      flexGrow = 1,
+      color = isHovered and "surface" or "on_surface",
+    }),
   }
   if pinned then
-    table.insert(titleChildren, 1, ui.glyph({ name = "pinned", size = 14 }))
+    table.insert(titleChildren, 1, ui.glyph({
+      name = "pinned",
+      size = 14,
+      color = isHovered and "surface" or "on_surface",
+    }))
   end
   local children = {
     ui.row({
+      key = file,
       flexGrow = 1,
       gap = 6,
       align = "center",
+      padding = 8,
+      paddingH = 12,
+      fill = isHovered and "tertiary" or "surface",
+      radius = 6 * cornerRadiusScale,
+      onHover = "onRowHover",
       onClick = function()
         openNote(file)
       end,
@@ -238,17 +256,34 @@ local function listRow(file)
 end
 
 local function listView()
+  local scratchFile = scratchName()
+  local isHovered = hoveredKey == scratchFile
   local rows = {
     -- The scratchpad is always present (created on first write) and not deletable from here.
     ui.row({ key = "scratchpad", gap = 6, align = "center" }, {
       ui.row({
+        key = scratchFile,
         flexGrow = 1,
         gap = 6,
         align = "center",
+        padding = 8,
+        paddingH = 12,
+        fill = isHovered and "tertiary" or "surface",
+        radius = 6 * cornerRadiusScale,
+        onHover = "onRowHover",
         onClick = "onOpenScratchpad",
       }, {
-        ui.glyph({ name = "pinned", size = 14 }),
-        ui.label({ text = tr("scratchpad"), maxLines = 1, flexGrow = 1 }),
+        ui.glyph({
+            name = "pinned",
+            size = 14,
+            color = isHovered and "surface" or "on_surface",
+          }),
+        ui.label({
+            text = tr("scratchpad"),
+            maxLines = 1,
+            flexGrow = 1,
+            color = isHovered and "surface" or "on_surface",
+          }),
       }),
     }),
   }
@@ -339,6 +374,7 @@ end
 
 function onOpen(_context)
   notesDir = noctalia.expandPath(noctalia.getConfig("notes_dir"))
+  cornerRadiusScale = noctalia.getSetting("shell.corner_radius_scale")
   local extension = noctalia.string.trim(noctalia.getConfig("extension")):gsub("^%.", "")
   if extension == "" then
     noctalia.notifyError(tr("title"), tr("bad_extension"))
@@ -481,6 +517,16 @@ end
 
 function onClosePanel()
   panel.close()
+end
+
+function onRowHover(state, key)
+  hoveredKey = (state == "true") and key or nil
+  -- if state == "true" then
+  --   hoveredKey = file
+  -- elseif hoveredKey == file then
+  --   hoveredKey = nil
+  -- end
+  render()
 end
 
 -- The launcher entry bumps "notes_bump" after writing note files (quick-capture

--- a/notes/plugin.toml
+++ b/notes/plugin.toml
@@ -1,6 +1,6 @@
 id = "noctalia/notes"
 name = "Notes"
-version = "1.0.4"
+version = "1.0.5"
 plugin_api = 9
 author = "noctalia"
 license = "MIT"


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Add hover, padding and corner radius to the rows in the Notes plugin. 

## Motivation

<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->
Tested with different corner roundness.

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: umbriel
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [x] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
