### PR TITLE
fix(translator): switched API client to resolve rate limit translatio…

### DIFF
--- a/translator/README.md
+++ b/translator/README.md
@@ -30,7 +30,7 @@ clipboard.
 ## Requirements
 
 The provider uses Google Translate's public `translate_a/single` endpoint, so it
-requires network access to `translate.google.com`.
+requires network access to `translate.googleapis.com`.
 
 ## Settings
 

--- a/translator/translator.luau
+++ b/translator/translator.luau
@@ -80,7 +80,7 @@ local function parseGoogle(body)
 end
 
 local function fetchGoogle(text, target, onDone)
-  local url = `https://translate.google.com/translate_a/single?client=gtx&sl=auto&tl={noctalia.string.urlEncode(target)}&dt=t&q={noctalia.string.urlEncode(text)}`
+  local url = `https://translate.googleapis.com/translate_a/single?client=dict-chrome-ex&sl=auto&tl={noctalia.string.urlEncode(target)}&dt=t&q={noctalia.string.urlEncode(text)}`
   noctalia.http({ url = url }, function(res)
     if not res.ok then
       onDone(nil, "Connection error - is the network up?")


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Switched to google translate api url endpoint to use "translate.googleapis.com" from "translate.google.com" and "client=dict-chrome-ex" from "client=gtx"

why ?
translate.google.com is meant for us humans to use, it's get rate limited very quickly
client=dict-chrome-ex is a parameter which is used by the official chrome translator extension, so it's pretty easy of rate limiting

## Motivation

users were facing "translation error" messages instead of the intended behavior, most likely due to rate limiting

<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
- Ran a shell loop to fire 100 rapid curl requests against the new endpoint to verify the rate limits, verified by Lysec as well.
- Manually tested the plugin as well

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: Umbriel
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
N/A

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [x] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.

## Additional Notes

N/A

<!-- Add follow-up notes, reviewer context, or known limitations. -->
