### PR TITLE
feat(translator): added DeepL as an alternative trnslation provider

### DIFF
--- a/translator/README.md
+++ b/translator/README.md
@@ -1,12 +1,12 @@
 # Translator
 
 Translator adds a launcher provider that translates text through Google
-Translate and copies the selected result to the clipboard.
+Translate or DeepL and copies the selected result to the clipboard.
 
 ## Plugin
 
 | Field | Value |
-| --- | --- |
+| - | - |
 | ID | `noctalia/translator` |
 | Entry | Launcher provider: `translate` |
 | Launcher Prefix | `/tr` |
@@ -29,14 +29,18 @@ clipboard.
 
 ## Requirements
 
-The provider uses Google Translate's public `translate_a/single` endpoint, so it
-requires network access to `translate.googleapis.com`.
+Depending on your configured setup, this plugin requires network access to
+either `translate.googleapis.com` (for Google Translate via the
+`translate_a/single` endpoint) or `api.deepl.com`/`.api-free.deepl.com` (for
+DeepL via the `v2/translate` endpoint)
 
 ## Settings
 
 | Setting | Type | Default | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | `target_lang` | `string` | `en` | Default target language code when the query does not include one. |
+| `provider` | `select` | `google` | The translation service to use (`google` or `deepl`). |
+| `deepl_api_key` | `string` | `""` | Your DeepL API Key (only required if you choose to use DeepL). |
 
 ## Notes
 

--- a/translator/README.md
+++ b/translator/README.md
@@ -6,7 +6,7 @@ Translate or DeepL and copies the selected result to the clipboard.
 ## Plugin
 
 | Field | Value |
-| - | - |
+| --- | --- |
 | ID | `noctalia/translator` |
 | Entry | Launcher provider: `translate` |
 | Launcher Prefix | `/tr` |
@@ -24,20 +24,23 @@ language and the text to translate.
 
 When the first word is a known language name, alias, or two- to three-letter
 language code, it is used as the target language. Otherwise the plugin uses the
-configured `target_lang`. Press Enter on a translation result to copy it to the
-clipboard.
+configured `target_lang`. If the provider rejects that first word as a language,
+the whole query is translated once more against `target_lang`, and the result
+row says which word was treated as text. Press Enter on a translation result to
+copy it to the clipboard.
 
 ## Requirements
 
-Depending on your configured setup, this plugin requires network access to
+Depending on the configured provider, this plugin requires network access to
 either `translate.googleapis.com` (for Google Translate via the
-`translate_a/single` endpoint) or `api.deepl.com`/`.api-free.deepl.com` (for
-DeepL via the `v2/translate` endpoint)
+`translate_a/single` endpoint) or `api.deepl.com` / `api-free.deepl.com` (for
+DeepL via the `v2/translate` endpoint). DeepL free-tier keys end in `:fx` and
+automatically select the free endpoint.
 
 ## Settings
 
 | Setting | Type | Default | Description |
-| - | - | - | - |
+| --- | --- | --- | --- |
 | `target_lang` | `string` | `en` | Default target language code when the query does not include one. |
 | `provider` | `select` | `google` | The translation service to use (`google` or `deepl`). |
 | `deepl_api_key` | `string` | `""` | Your DeepL API Key (only required if you choose to use DeepL). |

--- a/translator/plugin.toml
+++ b/translator/plugin.toml
@@ -16,7 +16,7 @@ entry = "translator.luau"
 prefix = "tr"
 glyph = "language"
 include_in_global_search = false
-debounce_ms = 300  # wait for typing to settle before calling Google
+debounce_ms = 300                # wait for typing to settle before calling Google
 
 
 [[setting]]
@@ -25,3 +25,20 @@ type = "string"
 label_key = "settings.target_lang.label"
 description_key = "settings.target_lang.description"
 default = "en"
+
+[[setting]]
+key = "provider"
+type = "select"
+label_key = "Translation Service Provider"
+default = "google"
+options = [
+  { value = "google", label_key = "Google Translate" },
+  { value = "deepl", label_key = "DeepL" },
+]
+
+[[setting]]
+key = "deepl_api_key"
+type = "string"
+label_key = "DeepL API Key"
+description_key = "Required only if DeepL is selected above"
+default = ""

--- a/translator/plugin.toml
+++ b/translator/plugin.toml
@@ -1,6 +1,6 @@
 id = "noctalia/translator"
 name = "Translator"
-version = "1.0.5"
+version = "1.0.7"
 plugin_api = 3
 author = "noctalia"
 license = "MIT"
@@ -26,19 +26,22 @@ label_key = "settings.target_lang.label"
 description_key = "settings.target_lang.description"
 default = "en"
 
+
 [[setting]]
 key = "provider"
 type = "select"
-label_key = "Translation Service Provider"
+label_key = "settings.provider.label"
 default = "google"
 options = [
-  { value = "google", label_key = "Google Translate" },
-  { value = "deepl", label_key = "DeepL" },
+  { value = "google", label_key = "settings.provider.options.google" },
+  { value = "deepl", label_key = "settings.provider.options.deepl" },
 ]
+description_key = "settings.provider.description"
+
 
 [[setting]]
 key = "deepl_api_key"
 type = "string"
-label_key = "DeepL API Key"
-description_key = "Required only if DeepL is selected above"
+label_key = "settings.deepl_api_key.label"
+description_key = "settings.deepl_api_key.description"
 default = ""

--- a/translator/plugin.toml
+++ b/translator/plugin.toml
@@ -7,7 +7,7 @@ license = "MIT"
 dependencies = []
 tags = ["language", "launcher"]
 icon = "language"
-description = "Translate text from the launcher via Google Translate."
+description = "Translate text from the launcher via Google Translate or DeepL."
 
 
 [[launcher_provider]]
@@ -16,7 +16,7 @@ entry = "translator.luau"
 prefix = "tr"
 glyph = "language"
 include_in_global_search = false
-debounce_ms = 300                # wait for typing to settle before calling Google
+debounce_ms = 300  # wait for typing to settle before calling the provider
 
 
 [[setting]]
@@ -31,12 +31,12 @@ default = "en"
 key = "provider"
 type = "select"
 label_key = "settings.provider.label"
+description_key = "settings.provider.description"
 default = "google"
 options = [
   { value = "google", label_key = "settings.provider.options.google" },
   { value = "deepl", label_key = "settings.provider.options.deepl" },
 ]
-description_key = "settings.provider.description"
 
 
 [[setting]]
@@ -45,3 +45,4 @@ type = "string"
 label_key = "settings.deepl_api_key.label"
 description_key = "settings.deepl_api_key.description"
 default = ""
+visible_when = { key = "provider", values = ["deepl"] }

--- a/translator/translations/en.json
+++ b/translator/translations/en.json
@@ -1,8 +1,20 @@
 {
   "settings": {
     "target_lang": {
-      "description": "Language code used when no language is given (e.g. en, fr, es)",
-      "label": "Default Target Language"
+      "label": "Default Target Language",
+      "description": "Language code used when no language is given (e.g. en, fr, es)"
+    },
+    "provider" : {
+      "label": "Translation Service Provider",
+      "description" : "Select the translation service to use for fetching results",
+      "options" : {
+        "google" : "Google Translate",
+        "deepl" : "DeepL"
+      }
+    },
+    "deepl_api_key" : {
+      "label" : "DeepL API Key",
+      "description" : "Required only if DeepL is selected above"
     }
   }
 }

--- a/translator/translations/en.json
+++ b/translator/translations/en.json
@@ -1,20 +1,20 @@
 {
   "settings": {
-    "target_lang": {
-      "label": "Default Target Language",
-      "description": "Language code used when no language is given (e.g. en, fr, es)"
+    "deepl_api_key": {
+      "description": "Required only if DeepL is selected above",
+      "label": "DeepL API Key"
     },
-    "provider" : {
+    "provider": {
+      "description": "Select the translation service to use for fetching results",
       "label": "Translation Service Provider",
-      "description" : "Select the translation service to use for fetching results",
-      "options" : {
-        "google" : "Google Translate",
-        "deepl" : "DeepL"
+      "options": {
+        "deepl": "DeepL",
+        "google": "Google Translate"
       }
     },
-    "deepl_api_key" : {
-      "label" : "DeepL API Key",
-      "description" : "Required only if DeepL is selected above"
+    "target_lang": {
+      "description": "Language code used when no language is given (e.g. en, fr, es)",
+      "label": "Default Target Language"
     }
   }
 }

--- a/translator/translator.luau
+++ b/translator/translator.luau
@@ -95,6 +95,46 @@ local function fetchGoogle(text, target, onDone)
   end)
 end
 
+local function fetchDeepL(text, target, onDone)
+  local key = noctalia.getConfig("deepl_api_key")
+
+  -- validate API key
+  if type(key) ~= "string" or noctalia.string.trim(key) == "" then
+    onDone(nil, "DeepL API Key is not present")
+    return
+  end
+
+  local url = "https://api.deepl.com/v2/translate"
+  if key:match(":fx$") then
+    url = "https://api-free.deepl.com/v2/translate"
+  end
+
+  local headers = {
+    "Authorization: DeepL-Auth-Key " .. key,
+    "Content-Type: application/json",
+  }
+
+  local body = noctalia.json.encode({
+    text = {text},
+    target_lang = string.upper(target)
+  }
+  )
+
+  noctalia.http({ method = "POST", url = url, headers = headers, body = body }, function(res)
+    if not res.ok then
+      onDone(nil, "DeepL connection error (check API key)")
+      return
+    end
+
+    local decoded = noctalia.json.decode(res.body)
+    if decoded and decoded.translations and type(decoded.translations[1]) == "table" then
+      onDone(decoded.translations[1].text, nil)
+    else
+      onDone(nil, "Translation error")
+    end
+  end)
+end
+
 local function hintRow(title, subtitle, glyph)
   return { id = title, title = title, subtitle = subtitle, glyph = glyph }
 end
@@ -151,7 +191,12 @@ function onQuery(query)
   launcher.setResults(query, { hintRow("Translating…", content, "loader") })
   if not pending[key] then
     pending[key] = true
-    fetchGoogle(content, target, function(translated, err)
+    local provider = noctalia.getConfig("provider")
+    local fetchProvider = fetchGoogle
+    if provider == "deepl" then
+      fetchProvider = fetchDeepL
+    end
+    fetchProvider(content, target, function(translated, err)
       pending[key] = nil
       if translated then
         cache[key] = translated

--- a/translator/translator.luau
+++ b/translator/translator.luau
@@ -13,11 +13,14 @@ DEFAULT_TARGET = if type(DEFAULT_TARGET) == "string" and DEFAULT_TARGET ~= "" th
 -- through to Google as-is, so uncommon languages still work.
 local LANGUAGES = {
   ar = { "arabic", "arabe" },
+  bg = { "bulgarian", "bulgare" },
   cs = { "czech", "tcheque" },
+  da = { "danish", "danois" },
   de = { "german", "allemand", "deutsch" },
   el = { "greek", "grec" },
   en = { "english", "anglais" },
   es = { "spanish", "espagnol", "espanol" },
+  et = { "estonian", "estonien" },
   fa = { "persian", "farsi", "persan" },
   fi = { "finnish", "finnois" },
   fr = { "french", "francais" },
@@ -28,13 +31,18 @@ local LANGUAGES = {
   it = { "italian", "italien" },
   ja = { "japanese", "japonais" },
   ko = { "korean", "coreen" },
+  lt = { "lithuanian", "lituanien" },
+  lv = { "latvian", "letton" },
   nl = { "dutch", "neerlandais" },
   no = { "norwegian", "norvegien" },
   pl = { "polish", "polonais" },
   pt = { "portuguese", "portugais" },
   ro = { "romanian", "roumain" },
   ru = { "russian", "russe" },
+  sk = { "slovak", "slovaque" },
+  sl = { "slovenian", "slovène", "slovene" },
   sv = { "swedish", "suedois" },
+  th = { "thai", "thailandais" },
   tr = { "turkish", "turc" },
   uk = { "ukrainian", "ukrainien" },
   vi = { "vietnamese", "vietnamien" },
@@ -80,10 +88,21 @@ local function parseGoogle(body)
 end
 
 local function fetchGoogle(text, target, onDone)
-  local url = `https://translate.google.com/translate_a/single?client=gtx&sl=auto&tl={noctalia.string.urlEncode(target)}&dt=t&q={noctalia.string.urlEncode(text)}`
+  local url =
+    `https://translate.google.com/translate_a/single?client=gtx&sl=auto&tl={noctalia.string.urlEncode(target)}&dt=t&q={noctalia.string.urlEncode(
+      text
+    )}`
   noctalia.http({ url = url }, function(res)
-    if not res.ok then
-      onDone(nil, "Connection error - is the network up?")
+    if not res.ok or (res.status and res.status >= 400) then
+      local error_msg = "Translation error"
+
+      if res.status == 400 then
+        error_msg = "Invalid target language code"
+      elseif res.status == 429 then
+        error_msg = "Rate limit exceeded: Please slow down"
+      end
+
+      onDone(nil, error_msg)
       return
     end
     local translated = parseGoogle(res.body)
@@ -96,33 +115,51 @@ local function fetchGoogle(text, target, onDone)
 end
 
 local function fetchDeepL(text, target, onDone)
-  local key = noctalia.getConfig("deepl_api_key")
+  local api_key = noctalia.getConfig("deepl_api_key")
 
   -- validate API key
-  if type(key) ~= "string" or noctalia.string.trim(key) == "" then
+  if type(api_key) ~= "string" or noctalia.string.trim(api_key) == "" then
     onDone(nil, "DeepL API Key is not present")
     return
   end
 
   local url = "https://api.deepl.com/v2/translate"
-  if key:match(":fx$") then
+  if api_key:match(":fx$") then
     url = "https://api-free.deepl.com/v2/translate"
   end
 
   local headers = {
-    "Authorization: DeepL-Auth-Key " .. key,
+    "Authorization: DeepL-Auth-Key " .. api_key,
     "Content-Type: application/json",
   }
 
+  local target_lang = string.upper(target)
+
+  -- DeepL uses NB for Norwegian Bokmål, and doesn't support NO
+  if target_lang == "NO" then
+    target_lang = "NB"
+  end
+
   local body = noctalia.json.encode({
-    text = {text},
-    target_lang = string.upper(target)
-  }
-  )
+    text = { text },
+    target_lang = target_lang,
+  })
 
   noctalia.http({ method = "POST", url = url, headers = headers, body = body }, function(res)
-    if not res.ok then
-      onDone(nil, "DeepL connection error (check API key)")
+    if not res.ok or (res.status and res.status >= 400) then
+      local error_msg = "Translation error"
+
+      if res.status == 400 then
+        error_msg = "Invalid target language code"
+      elseif res.status == 403 then
+        error_msg = "Authorization failed: Invalid DeepL API key"
+      elseif res.status == 429 then
+        error_msg = "Rate limit exceeded: Please slow down"
+      elseif res.status == 456 then
+        error_msg = "Quota exceeded: DeepL limit reached"
+      end
+
+      onDone(nil, error_msg)
       return
     end
 
@@ -181,7 +218,13 @@ function onQuery(query)
     return
   end
 
-  local key = `{target}|{content}`
+  local provider = noctalia.getConfig("provider")
+  local fetchProvider = fetchGoogle
+  if provider == "deepl" then
+    fetchProvider = fetchDeepL
+  end
+
+  local key = `{provider}|{target}|{content}`
   local cached = cache[key]
   if cached then
     launcher.setResults(query, { resultRow(cached, target) })
@@ -191,11 +234,6 @@ function onQuery(query)
   launcher.setResults(query, { hintRow("Translating…", content, "loader") })
   if not pending[key] then
     pending[key] = true
-    local provider = noctalia.getConfig("provider")
-    local fetchProvider = fetchGoogle
-    if provider == "deepl" then
-      fetchProvider = fetchDeepL
-    end
     fetchProvider(content, target, function(translated, err)
       pending[key] = nil
       if translated then

--- a/translator/translator.luau
+++ b/translator/translator.luau
@@ -7,7 +7,7 @@
 -- Translation uses Google Translate's public `translate_a/single` endpoint or DeepL's `v2/translate` endpoint.
 
 -- Common language aliases → ISO code. Any other 2–3 letter token is passed
--- through to Google as-is, so uncommon languages still work.
+-- through to the provider as-is, so uncommon languages still work.
 local LANGUAGES = {
   ar = { "arabic", "arabe" },
   bg = { "bulgarian", "bulgare" },
@@ -46,7 +46,8 @@ local LANGUAGES = {
   zh = { "chinese", "chinois", "mandarin" },
 }
 
--- target|text -> translation; pending guards against duplicate in-flight fetches.
+-- provider|target|text -> { text, target, recoveredFrom }; pending guards against
+-- duplicate in-flight fetches.
 local cache = {}
 local pending = {}
 
@@ -84,22 +85,32 @@ local function parseGoogle(body)
   return table.concat(parts)
 end
 
+-- Returned when a provider rejects the target language; drives the retry in onQuery.
+local INVALID_TARGET = "Invalid target language code"
+
+-- Maps a failed response to a user-facing message. `extra` holds provider-specific codes.
+local function httpError(res, extra)
+  if not res.ok or res.status == 0 then
+    return "Connection error - is the network up?"
+  end
+  if extra and extra[res.status] then
+    return extra[res.status]
+  end
+  if res.status == 400 then
+    return INVALID_TARGET
+  elseif res.status == 429 then
+    return "Rate limit exceeded: Please slow down"
+  elseif res.status >= 500 then
+    return "Internal Server Error / Service Unavailable: Try again later"
+  end
+  return "Translation error"
+end
+
 local function fetchGoogle(text, target, onDone)
-  -- stylua: ignore 
   local url = `https://translate.googleapis.com/translate_a/single?client=dict-chrome-ex&sl=auto&tl={noctalia.string.urlEncode(target)}&dt=t&q={noctalia.string.urlEncode(text)}`
   noctalia.http({ url = url }, function(res)
-    if not res.ok or (res.status and res.status >= 400) then
-      local errorMsg = "Translation error"
-
-      if res.status == 400 then
-        errorMsg = "Invalid target language code"
-      elseif res.status == 429 then
-        errorMsg = "Rate limit exceeded: Please slow down"
-      elseif res.status >= 500 then
-        errorMsg = "Internal Server Error / Service Unavailable: Try again later"
-      end
-
-      onDone(nil, errorMsg)
+    if not res.ok or res.status >= 400 then
+      onDone(nil, httpError(res))
       return
     end
     local translated = parseGoogle(res.body)
@@ -111,28 +122,33 @@ local function fetchGoogle(text, target, onDone)
   end)
 end
 
-local function fetchDeepL(text, target, onDone)
-  local apiKey = noctalia.getConfig("deepl_api_key")
+local DEEPL_ERRORS = {
+  [403] = "Authorization failed: Invalid DeepL API key",
+  [456] = "Quota exceeded: DeepL limit reached",
+}
 
-  -- validate API key
-  if type(apiKey) ~= "string" or noctalia.string.trim(apiKey) == "" then
+local function fetchDeepL(text, target, onDone)
+  -- Trim: a pasted key often carries trailing whitespace, which would break both the
+  -- free-tier suffix test below and the Authorization header.
+  local configured = noctalia.getConfig("deepl_api_key")
+  local apiKey = if type(configured) == "string" then noctalia.string.trim(configured) else ""
+  if apiKey == "" then
     onDone(nil, "DeepL API Key is not present")
     return
   end
 
-  local url = "https://api.deepl.com/v2/translate"
-  if apiKey:match(":fx$") then
-    url = "https://api-free.deepl.com/v2/translate"
-  end
+  -- Free-tier keys end in ":fx" and are only valid against the free endpoint.
+  local url = if apiKey:match(":fx$")
+    then "https://api-free.deepl.com/v2/translate"
+    else "https://api.deepl.com/v2/translate"
 
   local headers = {
-    "Authorization: DeepL-Auth-Key " .. apiKey,
+    `Authorization: DeepL-Auth-Key {apiKey}`,
     "Content-Type: application/json",
   }
 
-  local targetLang = string.upper(target)
-
-  -- DeepL uses NB for Norwegian Bokmål, and doesn't support NO
+  -- DeepL uses NB for Norwegian Bokmål and does not accept NO.
+  local targetLang = target:upper()
   if targetLang == "NO" then
     targetLang = "NB"
   end
@@ -143,27 +159,13 @@ local function fetchDeepL(text, target, onDone)
   })
 
   noctalia.http({ method = "POST", url = url, headers = headers, body = body }, function(res)
-    if not res.ok or (res.status and res.status >= 400) then
-      local errorMsg = "Translation error"
-
-      if res.status == 400 then
-        errorMsg = "Invalid target language code"
-      elseif res.status == 403 then
-        errorMsg = "Authorization failed: Invalid DeepL API key"
-      elseif res.status == 429 then
-        errorMsg = "Rate limit exceeded: Please slow down"
-      elseif res.status == 456 then
-        errorMsg = "Quota exceeded: DeepL limit reached"
-      elseif res.status >= 500 then
-        errorMsg = "Internal Server Error / Service Unavailable: Try again later"
-      end
-
-      onDone(nil, errorMsg)
+    if not res.ok or res.status >= 400 then
+      onDone(nil, httpError(res, DEEPL_ERRORS))
       return
     end
 
     local decoded = noctalia.json.decode(res.body)
-    if decoded and decoded.translations and type(decoded.translations[1]) == "table" then
+    if type(decoded) == "table" and type(decoded.translations) == "table" and type(decoded.translations[1]) == "table" then
       onDone(decoded.translations[1].text, nil)
     else
       onDone(nil, "Translation error")
@@ -175,11 +177,16 @@ local function hintRow(title, subtitle, glyph)
   return { id = title, title = title, subtitle = subtitle, glyph = glyph }
 end
 
-local function resultRow(translated, target)
+-- `entry.recoveredFrom` is set when the leading token was rejected as a language and
+-- retranslated as part of the text, so the row never passes that off as a plain hit.
+local function resultRow(entry)
+  local subtitle = if entry.recoveredFrom
+    then `Translation ({entry.target}), "{entry.recoveredFrom}" treated as text - press Enter to copy`
+    else `Translation ({entry.target}) - press Enter to copy`
   return {
-    id = translated,
-    title = translated,
-    subtitle = `Translation ({target}) - press Enter to copy`,
+    id = entry.text,
+    title = entry.text,
+    subtitle = subtitle,
     glyph = "language",
     presentation = "detail",
   }
@@ -226,12 +233,14 @@ function onQuery(query)
     fetchProvider = fetchDeepL
   end
 
-  -- helper func: isFallback -> tells if this is an auto retry attempt or not
-  local function requestTranslation(reqTarget, reqContent, isFallback)
+  -- recoveredFrom: the rejected leading token when this call is the retry.
+  -- aliasKey: cache slot of the rejected request, so an identical query skips it next time.
+  local function requestTranslation(reqTarget, reqContent, recoveredFrom, aliasKey)
     local reqKey = `{provider}|{reqTarget}|{reqContent}`
 
-    if cache[reqKey] then
-      launcher.setResults(query, { resultRow(cache[reqKey], reqTarget) })
+    local cached = cache[reqKey]
+    if cached then
+      launcher.setResults(query, { resultRow(cached) })
       return
     end
 
@@ -246,22 +255,31 @@ function onQuery(query)
     fetchProvider(reqContent, reqTarget, function(translated, err)
       pending[reqKey] = nil
 
-      if not translated and err == "Invalid target language code" and not isFallback then
-        -- if the request failed, try it once more, using the enitre input string, with default lang target
-        requestTranslation(defaultTarget, text, true)
+      if not translated then
+        -- The target came from the leading token, and the provider rejected it: retry once
+        -- with the whole input against the default target. Skipped when the retry would
+        -- repeat the same request, and never chained.
+        local retryable = err == INVALID_TARGET
+          and recoveredFrom == nil
+          and (reqTarget ~= defaultTarget or reqContent ~= text)
+        if retryable then
+          requestTranslation(defaultTarget, text, first, reqKey)
+          return
+        end
+        launcher.setResults(query, { hintRow(err or "Translation error", reqContent, "alert-triangle") })
         return
       end
 
-      if translated then
-        cache[reqKey] = translated
-        launcher.setResults(query, { resultRow(translated, reqTarget) })
-      else
-        launcher.setResults(query, { hintRow(err or "Translation error", reqContent, "alert-triangle") })
+      local entry = { text = translated, target = reqTarget, recoveredFrom = recoveredFrom }
+      cache[reqKey] = entry
+      if aliasKey then
+        cache[aliasKey] = entry
       end
+      launcher.setResults(query, { resultRow(entry) })
     end)
   end
 
-  requestTranslation(target, content, false)
+  requestTranslation(target, content)
 end
 
 function onActivate(id)

--- a/translator/translator.luau
+++ b/translator/translator.luau
@@ -4,10 +4,7 @@
 -- Usage from the launcher: `/tr <lang> <text>` - e.g. `/tr es hello world`.
 -- If the first word is not a language, the whole query is translated to the
 -- configured default target. Press Enter on a result to copy it to the clipboard.
--- Translation uses Google Translate's public `translate_a/single` endpoint.
-
-local DEFAULT_TARGET = noctalia.getConfig("target_lang")
-DEFAULT_TARGET = if type(DEFAULT_TARGET) == "string" and DEFAULT_TARGET ~= "" then DEFAULT_TARGET else "en"
+-- Translation uses Google Translate's public `translate_a/single` endpoint or DeepL's `v2/translate` endpoint.
 
 -- Common language aliases → ISO code. Any other 2–3 letter token is passed
 -- through to Google as-is, so uncommon languages still work.
@@ -88,22 +85,19 @@ local function parseGoogle(body)
 end
 
 local function fetchGoogle(text, target, onDone)
-  local url =
-    `https://translate.google.com/translate_a/single?client=gtx&sl=auto&tl={noctalia.string.urlEncode(target)}&dt=t&q={noctalia.string.urlEncode(
-      text
-    )}`
+  -- stylua: ignore 
   local url = `https://translate.googleapis.com/translate_a/single?client=dict-chrome-ex&sl=auto&tl={noctalia.string.urlEncode(target)}&dt=t&q={noctalia.string.urlEncode(text)}`
   noctalia.http({ url = url }, function(res)
     if not res.ok or (res.status and res.status >= 400) then
-      local error_msg = "Translation error"
+      local errorMsg = "Translation error"
 
       if res.status == 400 then
-        error_msg = "Invalid target language code"
+        errorMsg = "Invalid target language code"
       elseif res.status == 429 then
-        error_msg = "Rate limit exceeded: Please slow down"
+        errorMsg = "Rate limit exceeded: Please slow down"
       end
 
-      onDone(nil, error_msg)
+      onDone(nil, errorMsg)
       return
     end
     local translated = parseGoogle(res.body)
@@ -116,51 +110,51 @@ local function fetchGoogle(text, target, onDone)
 end
 
 local function fetchDeepL(text, target, onDone)
-  local api_key = noctalia.getConfig("deepl_api_key")
+  local apiKey = noctalia.getConfig("deepl_api_key")
 
   -- validate API key
-  if type(api_key) ~= "string" or noctalia.string.trim(api_key) == "" then
+  if type(apiKey) ~= "string" or noctalia.string.trim(apiKey) == "" then
     onDone(nil, "DeepL API Key is not present")
     return
   end
 
   local url = "https://api.deepl.com/v2/translate"
-  if api_key:match(":fx$") then
+  if apiKey:match(":fx$") then
     url = "https://api-free.deepl.com/v2/translate"
   end
 
   local headers = {
-    "Authorization: DeepL-Auth-Key " .. api_key,
+    "Authorization: DeepL-Auth-Key " .. apiKey,
     "Content-Type: application/json",
   }
 
-  local target_lang = string.upper(target)
+  local targetLang = string.upper(target)
 
   -- DeepL uses NB for Norwegian Bokmål, and doesn't support NO
-  if target_lang == "NO" then
-    target_lang = "NB"
+  if targetLang == "NO" then
+    targetLang = "NB"
   end
 
   local body = noctalia.json.encode({
     text = { text },
-    target_lang = target_lang,
+    target_lang = targetLang,
   })
 
   noctalia.http({ method = "POST", url = url, headers = headers, body = body }, function(res)
     if not res.ok or (res.status and res.status >= 400) then
-      local error_msg = "Translation error"
+      local errorMsg = "Translation error"
 
       if res.status == 400 then
-        error_msg = "Invalid target language code"
+        errorMsg = "Invalid target language code"
       elseif res.status == 403 then
-        error_msg = "Authorization failed: Invalid DeepL API key"
+        errorMsg = "Authorization failed: Invalid DeepL API key"
       elseif res.status == 429 then
-        error_msg = "Rate limit exceeded: Please slow down"
+        errorMsg = "Rate limit exceeded: Please slow down"
       elseif res.status == 456 then
-        error_msg = "Quota exceeded: DeepL limit reached"
+        errorMsg = "Quota exceeded: DeepL limit reached"
       end
 
-      onDone(nil, error_msg)
+      onDone(nil, errorMsg)
       return
     end
 
@@ -188,6 +182,9 @@ local function resultRow(translated, target)
 end
 
 function onQuery(query)
+  local defaultTarget = noctalia.getConfig("target_lang")
+  defaultTarget = if type(defaultTarget) == "string" and defaultTarget ~= "" then defaultTarget else "en"
+
   local text = noctalia.string.trim(query)
   if text == "" then
     launcher.setResults(query, { hintRow("Translate text", "Type: <lang> <text> - e.g. es hello", "language") })
@@ -202,7 +199,7 @@ function onQuery(query)
       target = code
       content = rest
     else
-      target = DEFAULT_TARGET
+      target = defaultTarget
       content = text
     end
   else
@@ -210,7 +207,7 @@ function onQuery(query)
       launcher.setResults(query, { hintRow("Type text to translate", `Target language: {text}`, "language") })
       return
     end
-    target = DEFAULT_TARGET
+    target = defaultTarget
     content = text
   end
 
@@ -219,32 +216,48 @@ function onQuery(query)
     return
   end
 
-  local provider = noctalia.getConfig("provider")
+  local provider = noctalia.getConfig("provider") or "google"
   local fetchProvider = fetchGoogle
   if provider == "deepl" then
     fetchProvider = fetchDeepL
   end
 
-  local key = `{provider}|{target}|{content}`
-  local cached = cache[key]
-  if cached then
-    launcher.setResults(query, { resultRow(cached, target) })
-    return
-  end
+  -- helper func: isFallback -> tells if this is an auto retry attempt or not
+  local function requestTranslation(reqTarget, reqContent, isFallback)
+    local reqKey = `{provider}|{reqTarget}|{reqContent}`
 
-  launcher.setResults(query, { hintRow("Translating…", content, "loader") })
-  if not pending[key] then
-    pending[key] = true
-    fetchProvider(content, target, function(translated, err)
-      pending[key] = nil
+    if cache[reqKey] then
+      launcher.setResults(query, { resultRow(cache[reqKey], reqTarget) })
+      return
+    end
+
+    launcher.setResults(query, { hintRow("Translating…", reqContent, "loader") })
+
+    if pending[reqKey] then
+      return
+    end
+
+    pending[reqKey] = true
+
+    fetchProvider(reqContent, reqTarget, function(translated, err)
+      pending[reqKey] = nil
+
+      if not translated and err == "Invalid target language code" and not isFallback then
+        -- if the request failed, try it once more, using the enitre input string, with default lang target
+        requestTranslation(defaultTarget, text, true)
+        return
+      end
+
       if translated then
-        cache[key] = translated
-        launcher.setResults(query, { resultRow(translated, target) })
+        cache[reqKey] = translated
+        launcher.setResults(query, { resultRow(translated, reqTarget) })
       else
-        launcher.setResults(query, { hintRow(err or "Translation error", content, "alert-triangle") })
+        launcher.setResults(query, { hintRow(err or "Translation error", reqContent, "alert-triangle") })
       end
     end)
   end
+
+  requestTranslation(target, content, false)
 end
 
 function onActivate(id)

--- a/translator/translator.luau
+++ b/translator/translator.luau
@@ -95,6 +95,8 @@ local function fetchGoogle(text, target, onDone)
         errorMsg = "Invalid target language code"
       elseif res.status == 429 then
         errorMsg = "Rate limit exceeded: Please slow down"
+      elseif res.status >= 500 then
+        errorMsg = "Internal Server Error / Service Unavailable: Try again later"
       end
 
       onDone(nil, errorMsg)
@@ -152,6 +154,8 @@ local function fetchDeepL(text, target, onDone)
         errorMsg = "Rate limit exceeded: Please slow down"
       elseif res.status == 456 then
         errorMsg = "Quota exceeded: DeepL limit reached"
+      elseif res.status >= 500 then
+        errorMsg = "Internal Server Error / Service Unavailable: Try again later"
       end
 
       onDone(nil, errorMsg)


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Added a new option to allow the use of DeepL as an alertnative translation provider
supports both free and pro tiers of DeepL (both use different API keys and URL endpoints)
free API keys have an extra ":fx" suffix and use "api-free.deepl.com" endpoint instead of "api.deepl.com"

<!-- What changed and why? -->

## Motivation

DeepL offers translations that many users (me myself & I) prefer over Google. They have a free tier as well which allows a pretty decent monthly limit which no one should realistically run through. And having another option won't hurt ;p

<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->
N/A

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
tested without an API key & with an invalid gibberish API key to make sure it throws an error
tested with API key to check for DeepL translations
for eg. "/tr en hallo" gives "hallo" back in google translate but gives "hello" in deepl

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: Umbriel
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

https://github.com/user-attachments/assets/dcee4728-4f84-41f3-a0da-9ae91ee7bc39

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [ ] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
