### PR TITLE
feat(screen_recorder): add CPU encoder option

### DIFF
--- a/screen_recorder/README.md
+++ b/screen_recorder/README.md
@@ -54,6 +54,7 @@ Replay controls are available only when `replay_enabled` is true.
 | `filename_pattern` | `string` | `recording_%Y%m%d_%H%M%S` | Date-format filename pattern without extension. |
 | `frame_rate` | `int` | `60` | Capture frame rate from 1 to 240. |
 | `video_codec` | `select` | `h264` | Video codec: `h264`, `hevc`, `av1`, `vp8`, or `vp9`. |
+| `video_encoder` | `select` | `gpu` | Video encoder: `gpu` (hardware) or `cpu` (software, always H.264). |
 | `video_qp` | `int` | `25` | Constant quality level from 0–51; lower values produce higher quality and larger files. |
 | `resolution` | `string` | `original` | `original` or a size like `1920x1080`. |
 | `audio_source` | `select` | `default_output` | Audio source: output, input, both, or none. |

--- a/screen_recorder/plugin.toml
+++ b/screen_recorder/plugin.toml
@@ -12,7 +12,7 @@
 
 id = "noctalia/screen_recorder"
 name = "Screen Recorder"
-version = "1.2.3"
+version = "1.3.0"
 plugin_api = 3
 author = "noctalia"
 license = "MIT"
@@ -65,6 +65,17 @@ options = [
   { value = "av1", label_key = "settings.video_codec.options.av1" },
   { value = "vp8", label_key = "settings.video_codec.options.vp8" },
   { value = "vp9", label_key = "settings.video_codec.options.vp9" },
+]
+
+[[setting]]
+key = "video_encoder"
+type = "select"
+label_key = "settings.video_encoder.label"
+description_key = "settings.video_encoder.description"
+default = "gpu"
+options = [
+    { value = "gpu", label_key = "settings.video_encoder.options.gpu"},
+    { value = "cpu", label_key = "settings.video_encoder.options.cpu"},
 ]
 
 [[setting]]

--- a/screen_recorder/recorder_service.luau
+++ b/screen_recorder/recorder_service.luau
@@ -197,6 +197,11 @@ local function buildResolutionFlag()
     return if res ~= "original" then `-s {res}` else ""
 end
 
+-- "cpu" forces the software encoder (h264-only), anything else keeps hardware encoding.
+local function buildEncoderFlag()
+    return if cfg("video_encoder") == "cpu" then "-encoder cpu" else ""
+end
+
 -- Capture modes a caller may request. An IPC override outside this set is
 -- discarded so an arbitrary payload can never reach the gpu-screen-recorder
 -- command line.
@@ -264,14 +269,19 @@ local function buildRecordCommand(focusedOutputName, sourceOverride)
 
     local fps = cfg("frame_rate")
     local codec = cfg("video_codec")
+    if cfg("video_encoder") == "cpu" and codec ~= "h264" then
+        log(`cpu encoder forces h264 (configured {codec})`)
+        codec = "h264"
+    end
     local qp = scaledVideoQp(codec, cfg("video_qp"))
     local cursor = if cfg("show_cursor") then "yes" else "no"
     local cr = cfg("color_range")
     local restore = if cfg("restore_portal") then "-restore-portal-session yes" else ""
     local audioFlags = buildAudioFlags()
     local resFlag = buildResolutionFlag()
+    local encoderFlag = buildEncoderFlag()
 
-    local flags = `-w {source} -f {fps} -k {codec} {audioFlags} -bm qp -ffmpeg-video-opts qp={qp} -cursor {cursor} -cr {cr} {resFlag} {restore} -v no -o "{outputPath}"`
+    local flags = `-w {source} -f {fps} -k {codec} {encoderFlag} {audioFlags} -bm qp -ffmpeg-video-opts qp={qp} -cursor {cursor} -cr {cr} {resFlag} {restore} -v no -o "{outputPath}"`
 
     log(`starting recording: mode={selectedVideoSource(sourceOverride)} target={source} output={outputPath} flags=[{flags}]`)
 
@@ -291,14 +301,19 @@ local function buildReplayCommand(focusedOutputName, sourceOverride)
     local storage = cfg("replay_storage")
     local fps = cfg("frame_rate")
     local codec = cfg("video_codec")
+    if cfg("video_encoder") == "cpu" and codec ~= "h264" then
+        log(`cpu encoder forces h264 (configured {codec})`)
+        codec = "h264"
+    end
     local qp = scaledVideoQp(codec, cfg("video_qp"))
     local cursor = if cfg("show_cursor") then "yes" else "no"
     local cr = cfg("color_range")
     local restore = if cfg("restore_portal") then "-restore-portal-session yes" else ""
     local audioFlags = buildAudioFlags()
     local resFlag = buildResolutionFlag()
+    local encoderFlag = buildEncoderFlag()
 
-    local flags = `-w {source} -c mp4 -f {fps} -k {codec} {audioFlags} -bm qp -ffmpeg-video-opts qp={qp} -cursor {cursor} -cr {cr} {resFlag} -r {duration} -replay-storage {storage} {restore} -v no -o "{dir}"`
+    local flags = `-w {source} -c mp4 -f {fps} -k {codec} {encoderFlag} {audioFlags} -bm qp -ffmpeg-video-opts qp={qp} -cursor {cursor} -cr {cr} {resFlag} -r {duration} -replay-storage {storage} {restore} -v no -o "{dir}"`
 
     log(`starting replay buffer: mode={selectedVideoSource(sourceOverride)} target={source} dir={dir} flags=[{flags}]`)
 

--- a/screen_recorder/translations/en.json
+++ b/screen_recorder/translations/en.json
@@ -120,6 +120,14 @@
         "vp9": "VP9"
       }
     },
+    "video_encoder": {
+      "description": "CPU encoding only supports H264, GPU is hardware-accelerated",
+      "label": "Video Encoder",
+      "options": {
+        "gpu": "GPU",
+        "cpu": "CPU"
+      }
+    },
     "video_qp": {
       "description": "Lower values produce higher quality and larger files",
       "label": "Video Quality (QP)"


### PR DESCRIPTION
## Summary

This PR adds a `video_encoder` setting (`gpu`/`cpu`, default `gpu`) to Screen Recorder. Selecting `cpu` passes `-encoder cpu` to gpu-screen-recorder, so recording works on GPUs with no hardware video encoder. Because the software encoder supports H.264 only, any other `video_codec` is forced to `h264`.

## Motivation

For the system which have no hardware video encoding or just want to try cpu encoding.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #45 

## Testing

- `python3 validate-plugins.py` = "Validated 13 plugin manifest(s)." all clean

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

Haven't tested yet

## Screenshots / Videos


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [x] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.

## Additional Notes

- Fix the issue after the review of the #49 instead of letting `encoder = cpu` + hevc/av1/vp8/vp9 fail at startup, the builders force `h264`.