### PR TITLE
fix(screen_recorder): silence portal target-selection cancellation error popup

### DIFF
--- a/screen_recorder/README.md
+++ b/screen_recorder/README.md
@@ -112,3 +112,5 @@ with a `screen_recorder:` prefix - watch it in the terminal running Noctalia or 
 `${XDG_STATE_HOME:-~/.local/state}/noctalia/screen_recorder/gpu-screen-recorder.log`
 (truncated per run); when a recording fails to start or ends early, the tail of that
 file is echoed into the Noctalia log so the underlying reason is visible.
+Cancelling the portal target selection dialog exits silently without any error
+notification popup, the cancellation is only written in the Noctalia log.

--- a/screen_recorder/plugin.toml
+++ b/screen_recorder/plugin.toml
@@ -12,7 +12,7 @@
 
 id = "noctalia/screen_recorder"
 name = "Screen Recorder"
-version = "1.3.0"
+version = "1.3.1"
 plugin_api = 3
 author = "noctalia"
 license = "MIT"

--- a/screen_recorder/recorder_service.luau
+++ b/screen_recorder/recorder_service.luau
@@ -71,6 +71,14 @@ local function logGsrTail(reason)
     end
 end
 
+-- Portal target selection cancelled by user shouldn't be a failure.
+-- Exits silently to idle with no error popup and writes a "cancelled by the user" line to logFile.
+local function portalCaptureCancelled()
+    local contents = noctalia.readFile(logFile)
+    if contents == nil or contents == "" then return false end
+    return contents:find("cancelled by the user", 1, true) ~= nil
+end
+
 -- Publish the recorder's status so the widget and shortcut can mirror it.
 local function publishStatus()
     local key = `{state}/{if isAvailable then "1" else "0"}`
@@ -161,6 +169,10 @@ local function notifyRecordingSavedIfPresent(notifyIfMissing)
     noctalia.runAsync(`sleep 0.5; test -s {shellQuote(savedPath)}`, function(result)
         if result.exitCode ~= 0 then
             if notifyIfMissing then
+                if portalCaptureCancelled() then
+                    log("target selection cancelled by user, no output file, return to idle")
+                    return
+                end
                 logGsrTail("recording stopped early with no output file")
                 noctalia.notifyError(noctalia.tr("notify.recording-failed"), noctalia.tr("notify.recording-stopped-early"))
             end
@@ -492,6 +504,9 @@ local function checkProcessState(processState)
             if processState == "recording" then
                 log("recording active")
                 setState("recording")
+            elseif portalCaptureCancelled() then
+                log("target selection cancelled by user")
+                setState("idle")
             else
                 log("recording never started (process not detected)")
                 logGsrTail("recording failed to start")
@@ -506,6 +521,9 @@ local function checkProcessState(processState)
                 log("replay buffer active")
                 setState("replaying")
                 noctalia.notify(noctalia.tr("notify.replay-active"))
+            elseif portalCaptureCancelled() then
+                log("target selection cancelled by user")
+                setState("idle")
             else
                 log("replay buffer never started (process not detected)")
                 logGsrTail("replay buffer failed to start")


### PR DESCRIPTION
## Summary

This PR fix the bug where cancelling the desktop-portal target selection dialog during screen recording popup an error notification, now returns silently to idle instead of raising a "Recording failed" error notification.

## Motivation

Cancelling the target selection shouldn't be treat as error, rather treat as normal user action.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #65 

## Testing

❯ python3 .github/workflows/validate-plugins.py
Validated 13 plugin manifest(s).

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

Didn't tested yet

## Screenshots / Videos


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [ ] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.

