### PR TITLE
fix(screen_recorder): use canceled (American one L)

### DIFF
--- a/screen_recorder/plugin.toml
+++ b/screen_recorder/plugin.toml
@@ -12,7 +12,7 @@
 
 id = "noctalia/screen_recorder"
 name = "Screen Recorder"
-version = "1.3.1"
+version = "1.3.2"
 plugin_api = 3
 author = "noctalia"
 license = "MIT"

--- a/screen_recorder/recorder_service.luau
+++ b/screen_recorder/recorder_service.luau
@@ -76,7 +76,8 @@ end
 local function portalCaptureCancelled()
     local contents = noctalia.readFile(logFile)
     if contents == nil or contents == "" then return false end
-    return contents:find("cancelled by the user", 1, true) ~= nil
+    return contents:find("canceled by the user", 1, true) ~= nil
+     or contents:find("cancelled by the user", 1, true) ~= nil
 end
 
 -- Publish the recorder's status so the widget and shortcut can mirror it.


### PR DESCRIPTION
## Summary

This PR fixes error popup from previous fix was still happening because of using `cancelled` instead of American one L `canceled`. I am keeping both just in case.

## Motivation

Just fixing my mistake, i should have reproduced and read the logs, now its good

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

#70 used `cancelled`

## Testing

❯ python3 .github/workflows/validate-plugins.py                                         3.6s
Validated 13 plugin manifest(s).

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [ ] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
