### PR TITLE
feat(screen_recorder): add custom audio sources

### DIFF
--- a/screen_recorder/plugin.toml
+++ b/screen_recorder/plugin.toml
@@ -12,7 +12,7 @@
 
 id = "noctalia/screen_recorder"
 name = "Screen Recorder"
-version = "1.3.2"
+version = "1.3.4"
 plugin_api = 3
 author = "noctalia"
 license = "MIT"

--- a/screen_recorder/plugin.toml
+++ b/screen_recorder/plugin.toml
@@ -79,6 +79,17 @@ options = [
 ]
 
 [[setting]]
+key = "video_bitrate_mode"
+type = "select"
+label_key = "settings.video_bitrate_mode.label"
+default = "qp"
+options = [
+  { value = "qp", label_key = "settings.video_bitrate_mode.options.qp" },
+  { value = "vbr", label_key = "settings.video_bitrate_mode.options.vbr" },
+  { value = "cbr", label_key = "settings.video_bitrate_mode.options.cbr" },
+]
+
+[[setting]]
 key = "video_qp"
 type = "int"
 label_key = "settings.video_qp.label"
@@ -86,6 +97,28 @@ description_key = "settings.video_qp.description"
 default = 25
 min = 0
 max = 51
+visible_when = { key = "video_bitrate_mode", values = ["qp"] }
+
+[[setting]]
+key = "video_quality"
+type = "select"
+label_key = "settings.video_quality.label"
+default = "very_high"
+options = [
+  { value = "medium", label_key = "settings.video_quality.options.medium" },
+  { value = "high", label_key = "settings.video_quality.options.high" },
+  { value = "very_high", label_key = "settings.video_quality.options.very_high" },
+  { value = "ultra", label_key = "settings.video_quality.options.ultra" },
+]
+visible_when = { key = "video_bitrate_mode", values = ["vbr"] }
+
+[[setting]]
+key = "video_bitrate"
+type = "string"
+label_key = "settings.video_bitrate.label"
+description_key = "settings.video_bitrate.description"
+default = "20000"
+visible_when = { key = "video_bitrate_mode", values = ["cbr"] }
 
 [[setting]]
 key = "resolution"

--- a/screen_recorder/plugin.toml
+++ b/screen_recorder/plugin.toml
@@ -103,8 +103,17 @@ options = [
   { value = "default_output", label_key = "settings.audio_source.options.default_output" },
   { value = "default_input", label_key = "settings.audio_source.options.default_input" },
   { value = "both", label_key = "settings.audio_source.options.both" },
+  { value = "custom", label_key = "settings.audio_source.options.custom" },
   { value = "none", label_key = "settings.audio_source.options.none" },
 ]
+
+[[setting]]
+key = "custom_audio_sources"
+type = "string"
+label_key = "settings.custom_audio_sources.label"
+description_key = "settings.custom_audio_sources.description"
+default = ""
+visible_when = { key = "audio_source", values = ["custom"] }
 
 [[setting]]
 key = "audio_codec"
@@ -125,7 +134,7 @@ description_key = "settings.audio_bitrate.description"
 default = 0
 min = 0
 max = 512
-visible_when = { key = "audio_source", values = ["default_output", "default_input", "both"] }
+visible_when = { key = "audio_source", values = ["default_output", "default_input", "both", "custom"] }
 
 [[setting]]
 key = "show_cursor"

--- a/screen_recorder/plugin.toml
+++ b/screen_recorder/plugin.toml
@@ -12,7 +12,7 @@
 
 id = "noctalia/screen_recorder"
 name = "Screen Recorder"
-version = "1.3.2"
+version = "1.3.3"
 plugin_api = 3
 author = "noctalia"
 license = "MIT"

--- a/screen_recorder/recorder_service.luau
+++ b/screen_recorder/recorder_service.luau
@@ -40,6 +40,28 @@ local function scaledVideoQp(codec, qp)
     return qp * (if codec == "vp8" then 2 elseif codec == "av1" or codec == "vp9" then 4 else 1)
 end
 
+local function buildVideoBitrateFlags(codec)
+    local mode = cfg("video_bitrate_mode")
+    if mode == "qp" then
+        local qp = scaledVideoQp(codec, cfg("video_qp"))
+        return `-bm qp -ffmpeg-video-opts qp={qp}`
+    end
+
+    if mode == "vbr" then
+        return `-bm vbr -q {cfg("video_quality")}`
+    end
+
+    if mode == "cbr" then
+        local bitrate = tonumber(cfg("video_bitrate"))
+        if not bitrate or bitrate <= 0 or bitrate ~= math.floor(bitrate) then
+            log(`invalid video bitrate: {cfg("video_bitrate")}`)
+            return nil
+        end
+        return `-bm cbr -q {bitrate}`
+    end
+    return ""
+end
+
 -- Where gpu-screen-recorder's own stdout/stderr is captured so its failure reason
 -- can be echoed back through noctalia.log (the process is detached, so this file is
 -- the only way to see why it never started or died early).
@@ -286,7 +308,10 @@ local function buildRecordCommand(focusedOutputName, sourceOverride)
         log(`cpu encoder forces h264 (configured {codec})`)
         codec = "h264"
     end
-    local qp = scaledVideoQp(codec, cfg("video_qp"))
+
+    local bitrateFlags = buildVideoBitrateFlags(codec)
+    if bitrateFlags == nil then return nil end
+
     local cursor = if cfg("show_cursor") then "yes" else "no"
     local cr = cfg("color_range")
     local restore = if cfg("restore_portal") then "-restore-portal-session yes" else ""
@@ -294,7 +319,7 @@ local function buildRecordCommand(focusedOutputName, sourceOverride)
     local resFlag = buildResolutionFlag()
     local encoderFlag = buildEncoderFlag()
 
-    local flags = `-w {source} -f {fps} -k {codec} {encoderFlag} {audioFlags} -bm qp -ffmpeg-video-opts qp={qp} -cursor {cursor} -cr {cr} {resFlag} {restore} -v no -o "{outputPath}"`
+    local flags = `-w {source} -f {fps} -k {codec} {encoderFlag} {audioFlags} {bitrateFlags} -cursor {cursor} -cr {cr} {resFlag} {restore} -v no -o "{outputPath}"`
 
     log(`starting recording: mode={selectedVideoSource(sourceOverride)} target={source} output={outputPath} flags=[{flags}]`)
 
@@ -318,7 +343,10 @@ local function buildReplayCommand(focusedOutputName, sourceOverride)
         log(`cpu encoder forces h264 (configured {codec})`)
         codec = "h264"
     end
-    local qp = scaledVideoQp(codec, cfg("video_qp"))
+
+    local bitrateFlags = buildVideoBitrateFlags(codec)
+    if bitrateFlags == nil then return nil end
+
     local cursor = if cfg("show_cursor") then "yes" else "no"
     local cr = cfg("color_range")
     local restore = if cfg("restore_portal") then "-restore-portal-session yes" else ""
@@ -326,7 +354,7 @@ local function buildReplayCommand(focusedOutputName, sourceOverride)
     local resFlag = buildResolutionFlag()
     local encoderFlag = buildEncoderFlag()
 
-    local flags = `-w {source} -c mp4 -f {fps} -k {codec} {encoderFlag} {audioFlags} -bm qp -ffmpeg-video-opts qp={qp} -cursor {cursor} -cr {cr} {resFlag} -r {duration} -replay-storage {storage} {restore} -v no -o "{dir}"`
+    local flags = `-w {source} -c mp4 -f {fps} -k {codec} {encoderFlag} {audioFlags} {bitrateFlags} -cursor {cursor} -cr {cr} {resFlag} -r {duration} -replay-storage {storage} {restore} -v no -o "{dir}"`
 
     log(`starting replay buffer: mode={selectedVideoSource(sourceOverride)} target={source} dir={dir} flags=[{flags}]`)
 

--- a/screen_recorder/recorder_service.luau
+++ b/screen_recorder/recorder_service.luau
@@ -202,6 +202,21 @@ local function buildAudioFlags()
     if source == "both" then
         return `-ac {codec} {bitrateFlag} -a "default_output|default_input"`
     end
+
+    if source == "custom" then
+        local sources = cfg("custom_audio_sources")
+        if sources == "" then return "" end
+
+        local flags = {}
+        for src in sources:gmatch("([^,]+)") do
+            src = noctalia.string.trim(src)
+            table.insert(flags, `-a {shellQuote(src)}`)
+        end
+
+        if #flags == 0 then return "" end
+        return `-ac {codec} {bitrateFlag} {table.concat(flags, " ")}`
+    end
+
     return `-ac {codec} {bitrateFlag} -a {source}`
 end
 

--- a/screen_recorder/translations/en.json
+++ b/screen_recorder/translations/en.json
@@ -30,8 +30,13 @@
         "both": "Output + Microphone",
         "default_input": "Microphone",
         "default_output": "System Output",
+        "custom": "Custom",
         "none": "No Audio"
       }
+    },
+    "custom_audio_sources": {
+      "description": "Comma-separated gpu-screen-recorder audio sources.",
+      "label": "Custom Audio Sources"
     },
     "color_range": {
       "label": "Color Range",

--- a/screen_recorder/translations/en.json
+++ b/screen_recorder/translations/en.json
@@ -110,6 +110,18 @@
     "show_cursor": {
       "label": "Show Cursor"
     },
+    "video_bitrate": {
+      "description": "Positive integer bitrate in kbps used for CBR mode",
+      "label": "Video Bitrate (kbps)"
+    },
+    "video_bitrate_mode": {
+      "label": "Bitrate Mode",
+      "options": {
+        "qp": "Constant Quality (QP)",
+        "vbr": "Variable Bitrate (VBR)",
+        "cbr": "Constant Bitrate (CBR)"
+      }
+    },
     "video_codec": {
       "label": "Video Codec",
       "options": {
@@ -131,6 +143,15 @@
     "video_qp": {
       "description": "Lower values produce higher quality and larger files",
       "label": "Video Quality (QP)"
+    },
+    "video_quality": {
+      "label": "Video Quality",
+      "options": {
+        "high": "High",
+        "medium": "Medium",
+        "ultra": "Ultra",
+        "very_high": "Very High"
+      }
     },
     "video_source": {
       "description": "GPU Screen Recorder capture mode; Focused records Noctalia's focused monitor",


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Added an option to be able to specify multiple comma separated custom audio sources.

## Motivation

I wanted to be able to specify all the options from my old setup.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
The options are valid and are passed correctly to gsr.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [x] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
