### PR TITLE
bitwarden: Autofocus keyboard input

### DIFF
--- a/bitwarden/plugin.toml
+++ b/bitwarden/plugin.toml
@@ -2,8 +2,8 @@
 
 id = "noctalia/bitwarden"
 name = "Bitwarden"
-version = "1.0.1"
-plugin_api = 8
+version = "1.0.2"
+plugin_api = 10
 author = "noctalia"
 license = "MIT"
 dependencies = ["bitwarden-cli"]
@@ -175,6 +175,7 @@ width = 300
 height = 148
 placement = "floating"
 position = "center"
+keyboard_focus = "exclusive"
 dismiss_on_outside_click = false
 
 [[panel]]


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Made the password entry panel autofocus with `keyboard_focus = "exclusive"` in the manifest, as well as the requisite changes to enable this(bumping api version/plugin version)

## Motivation

I've found that not having this autofocus is an unintuitive behavior, as many applications like polkit or pinentry do autofocus their password inputs by default, so having this as the default for this plugin works as well. Further, this change means you can unlock the vault and re-search without taking your hands off the keyboard, which is a nice QoL improvement.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #32

## Testing

Manually tested and this has the behavior I find to be correct.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

I don't think one is needed? this does not change the visual styling of the panels at all, only makes the auto-focus behavior change.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [x] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.

## Additional Notes

N/A