### PR TITLE
feat(wallhaven): add page number input

### DIFF
--- a/wallhaven/README.md
+++ b/wallhaven/README.md
@@ -18,7 +18,7 @@ Browse [Wallhaven](https://wallhaven.cc), download a wallpaper into your Noctali
    noctalia msg panel-toggle noctalia/wallhaven:browser
    ```
 
-3. Search by tags, adjust category and purity filters, paginate results, then click a wallpaper to download and apply.
+3. Search by tags, adjust category and purity filters, paginate results (or click the page counter, type a page number, and press Enter), then click a wallpaper to download and apply.
 
 ## Settings
 

--- a/wallhaven/panel.luau
+++ b/wallhaven/panel.luau
@@ -40,6 +40,8 @@ local resolutionWidth = ""
 local resolutionHeight = ""
 local aspectRatioIndex = 0
 local clearCounter = 0
+local pageInputCounter = 0
+local pageEditing = false
 
 local thumbPaths = {} -- id -> cache file path
 local thumbPending = {} -- id -> true while downloading
@@ -499,22 +501,22 @@ fetchWallpapers = function()
     `sorting={sortValue()}`,
     `order={sortOrder}`,
   }
-  
+
   local trimmed = noctalia.string.trim(query)
   if trimmed ~= "" then
     table.insert(params, `q={noctalia.string.urlEncode(trimmed)}`)
   end
-  
+
   local resolutionParamName, resolutionValue = buildResolutionParam()
   if resolutionParamName ~= nil and resolutionValue ~= nil then
     table.insert(params, `{resolutionParamName}={resolutionValue}`)
   end
-  
+
   local aspectRatio = aspectRatioParamValue()
   if aspectRatio ~= nil then
     table.insert(params, `ratios={aspectRatio}`)
   end
-  
+
   local url = API_BASE .. "/search?" .. table.concat(params, "&")
 
   noctalia.http({ url = url, headers = httpHeaders() }, function(res)
@@ -537,10 +539,10 @@ fetchWallpapers = function()
     local filteredWallpapers = {}
     local options = aspectRatioOptions()
     local selectedRatio = options[aspectRatioIndex + 1] or ""
-    
+
     for _, wallpaper in ipairs(data) do
       local include = true
-      
+
       -- Client-side aspect ratio check since API's ratio filter is often inaccurate
       if selectedRatio ~= "" then
         local res = wallpaper.resolution
@@ -551,7 +553,7 @@ fetchWallpapers = function()
             local ratio = w / h
             local isWide = ratio > 1
             local isPortrait = ratio < 1
-            
+
             if selectedRatio == "wide" and not isWide then
               include = false
             elseif selectedRatio == "portrait" and not isPortrait then
@@ -568,7 +570,7 @@ fetchWallpapers = function()
           end
         end
       end
-      
+
       if include then
         table.insert(filteredWallpapers, wallpaper)
       end
@@ -686,7 +688,7 @@ end
 
 render = function()
   normalizePurityFilters()
-  local pageLabel = if applying then tr("applying") else `Page {page} / {totalPages}`
+  local pageLabel = if applying then tr("applying") else `Page {page}`
   panel.render(ui.column({ flexGrow = 1, gap = 12, align = "stretch" }, {
     ui.row({ align = "center", justify = "space_between", gap = 8 }, {
       ui.label({ text = tr("title"), fontSize = 16, fontWeight = "bold", color = "on_surface", flexGrow = 1 }),
@@ -720,7 +722,24 @@ render = function()
           onClick = "onPrevPage",
           enabled = not loading and page > 1,
         }),
-        ui.label({ text = pageLabel, color = "on_surface_variant" }),
+        (if pageEditing then
+            ui.input({
+                key = `page_jump_{pageInputCounter}`,
+                placeholder = tostring(page),
+                width = 72,
+                focus = true,
+                onSubmit = "onPageEditSubmit",
+            })
+        else
+            ui.button({
+                key = "page_label",
+                text = pageLabel,
+                variant = "ghost",
+                tooltip = tr("page_jump_tooltip"),
+                onClick = "onPageLabelClicked",
+                enabled = not loading and not applying,
+            })),
+        ui.label({ text = if applying then "" else `/ {totalPages}`, color = "on_surface_variant" }),
         ui.button({
           key = "next_page",
           glyph = "chevron-right",
@@ -875,6 +894,31 @@ function onNextPage()
     page += 1
     fetchWallpapers()
   end
+end
+
+function onPageLabelClicked()
+  pageEditing = true
+  pageInputCounter += 1
+  render()
+end
+
+function onPageEditSubmit(value)
+  pageEditing = false
+  pageInputCounter += 1
+  if not loading then
+    local target = parsePositiveInt(noctalia.string.trim(value))
+    if target ~= nil then
+      if target > totalPages then
+        target = totalPages
+      end
+      if target ~= page then
+        page = target
+        fetchWallpapers()
+        return
+      end
+    end
+  end
+  render()
 end
 
 function onCloseClicked()

--- a/wallhaven/plugin.toml
+++ b/wallhaven/plugin.toml
@@ -1,6 +1,6 @@
 id = "noctalia/wallhaven"
 name = "Wallhaven"
-version = "1.2.0"
+version = "1.3.0"
 plugin_api = 9
 author = "noctalia"
 license = "MIT"

--- a/wallhaven/translations/en.json
+++ b/wallhaven/translations/en.json
@@ -15,6 +15,7 @@
   "filter_resolution": "Resolution",
   "filter_sort": "Sort",
   "loading": "Loading wallpapers…",
+  "page_jump_tooltip": "Jump to page",
   "purity_nsfw": "NSFW",
   "purity_sfw": "SFW",
   "purity_sketchy": "Sketchy",


### PR DESCRIPTION
## Summary

This PR adds page number input in wallhaven plugin, now user can click on "Current Page" it will turn into a input box where they can type a page number they want to jump to and press ENTER. Just like we have seen browser doing.

## Motivation

Continuous clicking left/right to switch page incase you want go back to particular page isn't a good experience.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #23 

## Testing

❯ python3 .github/workflows/validate-plugins.py                                         3.3s
Validated 13 plugin manifest(s).
- I tested the plugin after adding an source and it is working as expected. 

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: Umbriel
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos


https://github.com/user-attachments/assets/b698998e-0de1-44d9-8ace-53368b5cb566

> I am using the umbriel portal to record and the video turned out laggy, though while recording i had no lagging experience then i checke the issues. There is an issue mentioning it:- https://github.com/noctalia-dev/xdg-desktop-portal-umbriel/issues/10
> I just thought about adding it here

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I self-reviewed the changes.
- [x] I added or updated `translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.

## Additional notes 

The white lines edit appears when I was testing nd even I undo those after saving file it comes back or something. It's alright, not affecting anything 